### PR TITLE
Linux Mint logos: color optimization & mintwelcome

### DIFF
--- a/src/apps/scalable/linuxmint-logo-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-badge.svg
@@ -11,13 +11,36 @@
    sodipodi:docname="linuxmint-logo-badge.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient828">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop930" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient828"
+       id="linearGradient830"
+       x1="263.23047"
+       y1="291.69141"
+       x2="262.86871"
+       y2="375.27399"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,15 +49,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="11.2"
-     inkscape:cx="21.294643"
-     inkscape:cy="53.660714"
+     inkscape:cx="51.830357"
+     inkscape:cy="61.607143"
      inkscape:document-units="px"
      inkscape:current-layer="layer1-7-0"
      showgrid="false"
      inkscape:pagecheckerboard="true"
      units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1358"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1" />
@@ -61,7 +84,7 @@
        inkscape:label="Calque 1"
        style="fill:#87cf3e;fill-opacity:1;opacity:1">
       <path
-         style="opacity:1;fill:#a3be8c;fill-opacity:1;stroke:none;stroke-width:5.47888851;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:1;fill:url(#linearGradient830);fill-opacity:1;stroke:none;stroke-width:5.47888851;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 263.23047,291.69141 a 41.649708,41.649708 0 0 0 -41.65039,41.65039 41.649708,41.649708 0 0 0 41.65039,41.64843 41.649708,41.649708 0 0 0 41.64844,-41.64843 41.649708,41.649708 0 0 0 -41.64844,-41.65039 z m -26.50586,17.03906 h 7.57422 v 34.07617 c 0,4.22712 3.34514,7.57422 7.57226,7.57422 h 22.71875 c 4.22712,0 7.57227,-3.3471 7.57227,-7.57422 V 323.875 c 0,-2.13599 -1.65113,-3.78516 -3.78711,-3.78516 -2.13598,0 -3.78516,1.64917 -3.78516,3.78516 v 18.93164 h -7.57422 V 323.875 c 10e-6,-2.13599 -1.64917,-3.78516 -3.78515,-3.78516 -2.13599,0 -3.78711,1.64917 -3.78711,3.78516 v 18.93164 h -7.57227 V 323.875 c 0,-6.22856 5.13082,-11.35938 11.35938,-11.35938 2.90978,10e-6 5.55293,1.15026 7.57226,2.97852 2.01934,-1.82826 4.66249,-2.97852 7.57227,-2.97852 6.22856,10e-6 11.35938,5.13082 11.35938,11.35938 v 18.93164 c -10e-6,8.3197 -6.82484,15.14648 -15.14454,15.14648 h -22.71875 c -8.31969,0 -15.14648,-6.82678 -15.14648,-15.14648 z"
          transform="matrix(1.118055,0,0,1.118055,-247.73887,-122.26071)"
          id="path1374-3"

--- a/src/apps/scalable/linuxmint-logo-filled-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-badge.svg
@@ -11,13 +11,57 @@
    sodipodi:docname="linuxmint-logo-filled-badge.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1060">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop1056" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop1058" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient830">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop826" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop828" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient832"
+       x1="196.842"
+       y1="31.418701"
+       x2="193.14655"
+       y2="383.39557"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1060"
+       id="linearGradient1062"
+       x1="47.077255"
+       y1="203.89368"
+       x2="48.64706"
+       y2="296.6377"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,15 +70,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-64.375"
+     inkscape:cx="1.6964286"
      inkscape:cy="40.535714"
      inkscape:document-units="px"
      inkscape:current-layer="layer1-0"
      showgrid="false"
      inkscape:pagecheckerboard="true"
      units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1358"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1" />
@@ -64,9 +108,9 @@
          cy="250.43332"
          cx="46.566666"
          id="path1374-6"
-         style="opacity:1;fill:#a3be8c;fill-opacity:1;stroke:none;stroke-width:6.12569904;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="opacity:1;fill:url(#linearGradient1062);fill-opacity:1;stroke:none;stroke-width:6.12569904;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <g
-         style="stroke:#ffffff;stroke-opacity:1;fill:#eceff4;fill-opacity:1"
+         style="stroke:#ffffff;stroke-opacity:1;fill:url(#linearGradient832);fill-opacity:1"
          id="layer3"
          inkscape:label="Layer 1"
          transform="matrix(0.26458333,0,0,0.26458333,-4.2333326,195.39998)">
@@ -74,7 +118,7 @@
            inkscape:connector-curvature="0"
            id="path4193"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eceff4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       </g>
     </g>
   </g>

--- a/src/apps/scalable/linuxmint-logo-filled-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-badge.svg
@@ -58,7 +58,7 @@
        id="linearGradient1062"
        x1="47.077255"
        y1="203.89368"
-       x2="48.64706"
+       x2="46.15699"
        y2="296.6377"
        gradientUnits="userSpaceOnUse" />
   </defs>

--- a/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
@@ -21,15 +21,15 @@
      id="defs2">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient1252">
+       id="linearGradient838">
       <stop
          style="stop-color:#d8dee9;stop-opacity:1"
          offset="0"
-         id="stop1248" />
+         id="stop834" />
       <stop
          style="stop-color:#eceff4;stop-opacity:1"
          offset="1"
-         id="stop1250" />
+         id="stop836" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
@@ -54,12 +54,12 @@
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1252"
-       id="linearGradient1254"
-       x1="178.73627"
-       y1="44.43684"
-       x2="181.79204"
-       y2="372.54388"
+       xlink:href="#linearGradient838"
+       id="linearGradient840"
+       x1="178.14952"
+       y1="47.734074"
+       x2="177.79837"
+       y2="371.38623"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -112,9 +112,9 @@
          id="layer3-2-3-6"
          inkscape:label="Layer 1"
          transform="matrix(0.12154991,0,0,0.12154991,111.42789,203.16749)"
-         style="fill:#eceff4;fill-opacity:1">
+         style="fill:url(#linearGradient840);fill-opacity:1">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1254);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient840);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-6-7-1"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
@@ -47,19 +47,19 @@
        inkscape:collect="always"
        xlink:href="#linearGradient830"
        id="linearGradient832"
-       x1="497.39835"
-       y1="779.58167"
+       x1="496.48831"
+       y1="788.59967"
        x2="497.19086"
-       y2="946.88409"
+       y2="938.95441"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient1252"
        id="linearGradient1254"
        x1="178.73627"
-       y1="26.696165"
+       y1="44.43684"
        x2="181.79204"
-       y2="389.53027"
+       y2="372.54388"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview

--- a/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
@@ -11,13 +11,57 @@
    sodipodi:docname="linuxmint-logo-filled-leaf-badge.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1252">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop1248" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop1250" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient830">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop826" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop828" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient832"
+       x1="497.39835"
+       y1="779.58167"
+       x2="497.19086"
+       y2="946.88409"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1252"
+       id="linearGradient1254"
+       x1="178.73627"
+       y1="26.696165"
+       x2="181.79204"
+       y2="389.53027"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,15 +70,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-26.339286"
-     inkscape:cy="40.535714"
+     inkscape:cx="24.196429"
+     inkscape:cy="40.178571"
      inkscape:document-units="px"
      inkscape:current-layer="g1214"
      showgrid="false"
      inkscape:pagecheckerboard="true"
      units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1358"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1" />
@@ -62,7 +106,7 @@
          id="rect1013-2"
          transform="scale(0.26458333)"
          d="m 414.36914,788.04883 v 48.05664 h 19.76953 V 845.75 l 0.0254,37.82422 c 0,31.15105 27.05922,54.78906 58.23828,54.78906 h 89.63672 V 843.2832 c 0,-31.17906 -27.02926,-54.78515 -58.23633,-54.78515 l -26.07617,-0.0586 z"
-         style="opacity:1;fill:#a3be8c;fill-opacity:1;stroke:none;stroke-width:6.58000278;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:1;fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-width:6.58000278;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <g
          id="layer3-2-3-6"
@@ -70,7 +114,7 @@
          transform="matrix(0.12154991,0,0,0.12154991,111.42789,203.16749)"
          style="fill:#eceff4;fill-opacity:1">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eceff4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1254);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-6-7-1"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-filled-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf.svg
@@ -11,13 +11,78 @@
    sodipodi:docname="linuxmint-logo-filled-leaf.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1020">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop1016" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop1018" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient936">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop932" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop934" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient852">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop848" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop850" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient852"
+       id="linearGradient854"
+       x1="583.51019"
+       y1="483.7327"
+       x2="583.49237"
+       y2="680.69055"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient936"
+       id="linearGradient938"
+       x1="591.39874"
+       y1="484.45465"
+       x2="592.75208"
+       y2="679.90662"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1020"
+       id="linearGradient1022"
+       x1="180.05893"
+       y1="13.427755"
+       x2="184.52621"
+       y2="403.81842"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,15 +91,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-64.375"
+     inkscape:cx="-0.089285714"
      inkscape:cy="40.535714"
      inkscape:document-units="px"
      inkscape:current-layer="g1108"
      showgrid="false"
      inkscape:pagecheckerboard="true"
      units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1358"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1" />
@@ -64,7 +129,7 @@
         <g
            id="g5159">
           <path
-             style="display:inline;opacity:1;fill:#a3be8c;fill-opacity:1;fill-rule:evenodd;stroke-width:1.12712526"
+             style="display:inline;opacity:1;fill:url(#linearGradient854);fill-opacity:1;fill-rule:evenodd;stroke-width:1.12712526"
              d="m 671.90956,642.97352 c 0,-25.20809 0,-84.67388 0,-84.67388 0,-28.28854 -24.808,-51.21991 -55.41715,-51.21991 h -31.76933 v -0.0683 L 498.79913,506.636 v 30.8947 c 0,0 7.01578,0 13.18985,0 9.20682,0 10.8333,6.35563 10.8333,15.15255 l 0.0683,54.61836 c 0,28.28856 24.8081,51.21988 55.38309,51.21988 h 75.48956 c 9.67782,0 18.14635,-6.12887 18.14635,-15.548 z"
              id="path2576-0-3-7-4-8"
              sodipodi:nodetypes="cccccccsccccc"
@@ -73,7 +138,7 @@
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccccccccccccccccccsccccc"
              d="m 577.77171,670.2471 c -36.45888,0 -68.09808,-27.63927 -68.09808,-64.06549 l -0.0327,-44.22927 V 550.67389 H 486.5263 v -56.19662 l 97.47492,0.45904 30.49168,0.0656 c 36.49165,0 68.09808,27.60638 68.09808,64.0653 V 670.24709 H 577.77177 v 0 0 z m 89.96674,-29.82397 c 0,-24.22031 0,-81.35591 0,-81.35591 0,-27.18004 -23.83588,-49.21283 -53.2456,-49.21283 h -30.52444 v -0.0656 l -82.55696,-0.36074 v 26.39336 c 0,0 3.31589,0 9.24802,0 6.27863,0 13.83375,5.9003 13.83375,14.55879 l 0.0656,55.76887 c 0,27.18005 23.83599,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43527,-5.88872 17.43527,-14.93876 z"
-             style="display:inline;overflow:visible;visibility:visible;fill:#eceff4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12712526;marker:none;enable-background:accumulate"
+             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient938);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12712526;marker:none;enable-background:accumulate"
              id="path4210-8-6-5-7-3" />
         </g>
       </g>
@@ -83,7 +148,7 @@
          inkscape:label="Layer 1"
          transform="matrix(0.27212591,0,0,0.27212591,-37.922389,261.72722)">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eceff4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1022);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-6-9-2-91"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-filled-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf.svg
@@ -21,18 +21,6 @@
      id="defs2">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient1020">
-      <stop
-         style="stop-color:#d8dee9;stop-opacity:1"
-         offset="0"
-         id="stop1016" />
-      <stop
-         style="stop-color:#eceff4;stop-opacity:1"
-         offset="1"
-         id="stop1018" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
        id="linearGradient936">
       <stop
          style="stop-color:#d8dee9;stop-opacity:1"
@@ -59,28 +47,28 @@
        inkscape:collect="always"
        xlink:href="#linearGradient852"
        id="linearGradient854"
-       x1="583.51019"
-       y1="483.7327"
-       x2="583.49237"
-       y2="680.69055"
+       x1="577.97504"
+       y1="496.07022"
+       x2="577.77179"
+       y2="670.24707"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient936"
        id="linearGradient938"
-       x1="591.39874"
-       y1="484.45465"
-       x2="592.75208"
-       y2="679.90662"
+       x1="590.57263"
+       y1="494.61368"
+       x2="591.80859"
+       y2="670.54828"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1020"
-       id="linearGradient1022"
-       x1="180.05893"
-       y1="13.427755"
-       x2="184.52621"
-       y2="403.81842"
+       xlink:href="#linearGradient936"
+       id="linearGradient847"
+       x1="155.38577"
+       y1="33.811779"
+       x2="153.88199"
+       y2="382.81619"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -143,12 +131,12 @@
         </g>
       </g>
       <g
-         style="fill:#eceff4;fill-opacity:1"
+         style="fill:url(#linearGradient847);fill-opacity:1"
          id="layer3-2-5-2-2"
          inkscape:label="Layer 1"
          transform="matrix(0.27212591,0,0,0.27212591,-37.922389,261.72722)">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1022);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient847);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-6-9-2-91"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-filled-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-ring.svg
@@ -11,13 +11,66 @@
    sodipodi:docname="linuxmint-logo-filled-ring.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1190">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop1186" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop1188" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient832">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop828" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop830" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient832"
+       id="linearGradient834"
+       x1="177.35075"
+       y1="243.33424"
+       x2="177.1613"
+       y2="265.99271"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient1192"
+       x1="55.033203"
+       y1="186.93359"
+       x2="55.200191"
+       y2="296.56616"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1190"
+       id="linearGradient1456"
+       x1="191.99951"
+       y1="0.0010204725"
+       x2="190.90784"
+       y2="417.06311"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,15 +79,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-64.375"
-     inkscape:cy="40.535714"
+     inkscape:cx="13.839286"
+     inkscape:cy="44.285714"
      inkscape:document-units="px"
      inkscape:current-layer="g909"
      showgrid="false"
      inkscape:pagecheckerboard="true"
      units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1358"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1" />
@@ -64,7 +117,7 @@
          cy="254.72061"
          cx="177.20531"
          id="path1393-5"
-         style="opacity:1;fill:#a3be8c;fill-opacity:1;stroke:none;stroke-width:1.02427185;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="opacity:1;fill:url(#linearGradient834);fill-opacity:1;stroke:none;stroke-width:1.02427185;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <g
          style="fill:#eceff4;fill-opacity:1;stroke:none;stroke-opacity:1"
          inkscape:label="Calque 1"
@@ -74,7 +127,7 @@
            inkscape:connector-curvature="0"
            id="path1374-2-6-7"
            d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eceff4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1192);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <g
            transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)"
            inkscape:label="Layer 1"
@@ -84,7 +137,7 @@
              inkscape:connector-curvature="0"
              id="path4193-1-9-4"
              d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eceff4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1456);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         </g>
       </g>
     </g>

--- a/src/apps/scalable/linuxmint-logo-filled-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-ring.svg
@@ -21,15 +21,15 @@
      id="defs2">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient1190">
+       id="linearGradient841">
       <stop
          style="stop-color:#d8dee9;stop-opacity:1"
          offset="0"
-         id="stop1186" />
+         id="stop837" />
       <stop
          style="stop-color:#eceff4;stop-opacity:1"
          offset="1"
-         id="stop1188" />
+         id="stop839" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
@@ -54,22 +54,13 @@
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1190"
-       id="linearGradient1192"
+       xlink:href="#linearGradient841"
+       id="linearGradient1406"
+       gradientUnits="userSpaceOnUse"
        x1="55.033203"
        y1="186.93359"
-       x2="55.200191"
-       y2="296.56616"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient1190"
-       id="linearGradient1456"
-       x1="191.99951"
-       y1="0.0010204725"
-       x2="190.90784"
-       y2="417.06311"
-       gradientUnits="userSpaceOnUse" />
+       x2="55.675446"
+       y2="296.95972" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -119,7 +110,7 @@
          id="path1393-5"
          style="opacity:1;fill:url(#linearGradient834);fill-opacity:1;stroke:none;stroke-width:1.02427185;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <g
-         style="fill:#eceff4;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="fill:url(#linearGradient1406);fill-opacity:1;stroke:none;stroke-opacity:1"
          inkscape:label="Calque 1"
          id="layer1-6-7-4"
          transform="matrix(0.20596182,0,0,0.20596182,166.01601,204.83306)">
@@ -127,17 +118,17 @@
            inkscape:connector-curvature="0"
            id="path1374-2-6-7"
            d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1192);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1406);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <g
            transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)"
            inkscape:label="Layer 1"
            id="layer3-9-56-4"
-           style="fill:#eceff4;fill-opacity:1;stroke:none;stroke-opacity:1">
+           style="fill:url(#linearGradient1406);fill-opacity:1;stroke:none;stroke-opacity:1">
           <path
              inkscape:connector-curvature="0"
              id="path4193-1-9-4"
              d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1456);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1406);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         </g>
       </g>
     </g>

--- a/src/apps/scalable/linuxmint-logo-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-leaf-badge.svg
@@ -35,10 +35,10 @@
        inkscape:collect="always"
        xlink:href="#linearGradient827"
        id="linearGradient829"
-       x1="12.93671"
-       y1="271.7305"
-       x2="13.062551"
-       y2="296.97681"
+       x1="12.96566"
+       y1="272.91965"
+       x2="13.104102"
+       y2="295.69534"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview

--- a/src/apps/scalable/linuxmint-logo-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-leaf-badge.svg
@@ -11,13 +11,36 @@
    sodipodi:docname="linuxmint-logo-leaf-badge.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient827">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop823" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop825" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient827"
+       id="linearGradient829"
+       x1="12.93671"
+       y1="271.7305"
+       x2="13.062551"
+       y2="296.97681"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,8 +49,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-3.5714286"
-     inkscape:cy="45.625"
+     inkscape:cx="36.785714"
+     inkscape:cy="45.267857"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -35,8 +58,8 @@
      units="px"
      inkscape:window-width="1619"
      inkscape:window-height="945"
-     inkscape:window-x="747"
-     inkscape:window-y="344"
+     inkscape:window-x="299"
+     inkscape:window-y="52"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata5">
@@ -56,7 +79,7 @@
      id="layer1"
      transform="translate(0,-271.59998)">
     <path
-       style="opacity:1;fill:#a3be8c;fill-opacity:1;stroke:none;stroke-width:0.99678552;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:1;fill:url(#linearGradient829);fill-opacity:1;stroke:none;stroke-width:0.99678552;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m -5.0000018e-8,272.91461 v 7.28019 H 2.9946537 v 1.46089 l 0.00413,5.72989 c 0,4.71899 4.0989904,8.29977 8.8222123,8.29977 H 25.4 v -14.40327 c 0,-4.72323 -4.094747,-8.29925 -8.822211,-8.29925 l -3.950152,-0.009 z M 6.6331937,277.12676 h 2.2164047 v 9.97357 c 0,1.23716 0.9792403,2.2164 2.2164076,2.2164 h 6.648696 c 1.237166,0 2.216407,-0.97924 2.216407,-2.2164 v -5.54076 c 0,-0.62514 -0.4828,-1.10846 -1.107945,-1.10846 -0.625147,0 -1.108462,0.48332 -1.108462,1.10846 v 5.54076 h -2.216405 v -5.54076 c 0,-0.62514 -0.482798,-1.10846 -1.107944,-1.10846 -0.625145,0 -1.107944,0.48332 -1.107944,1.10846 v 5.54076 h -2.216403 v -5.54076 c 0,-1.82293 1.501413,-3.32434 3.324347,-3.32434 0.851615,0 1.625398,0.33618 2.216404,0.87126 0.591009,-0.53508 1.364792,-0.87126 2.216407,-0.87126 1.822934,0 3.324348,1.50141 3.324348,3.32434 v 5.54076 c 0,2.43495 -1.997856,4.43281 -4.43281,4.43281 h -6.648696 c -2.4349563,0 -4.4328123,-1.99786 -4.4328123,-4.43281 z"
        id="rect1013"
        inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-leaf.svg
@@ -36,10 +36,10 @@
        xlink:href="#linearGradient883"
        id="linearGradient1109"
        gradientUnits="userSpaceOnUse"
-       x1="31.261635"
-       y1="176.302"
-       x2="31.503658"
-       y2="219.43275" />
+       x1="30.307899"
+       y1="178.14514"
+       x2="30.069843"
+       y2="217.36218" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient883"

--- a/src/apps/scalable/linuxmint-logo-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-leaf.svg
@@ -11,13 +11,54 @@
    sodipodi:docname="linuxmint-logo-leaf.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient883">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop879" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop881" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient883"
+       id="linearGradient1109"
+       gradientUnits="userSpaceOnUse"
+       x1="31.261635"
+       y1="176.302"
+       x2="31.503658"
+       y2="219.43275" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient883"
+       id="linearGradient1111"
+       gradientUnits="userSpaceOnUse"
+       x1="177.52783"
+       y1="204.49129"
+       x2="178.84206"
+       y2="400.20526" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient883"
+       id="linearGradient1433"
+       gradientUnits="userSpaceOnUse"
+       x1="164.6869"
+       y1="15.429844"
+       x2="168.62326"
+       y2="398.61319" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,7 +67,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-3.5714286"
+     inkscape:cx="44.821429"
      inkscape:cy="45.625"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -35,8 +76,8 @@
      units="px"
      inkscape:window-width="1619"
      inkscape:window-height="945"
-     inkscape:window-x="747"
-     inkscape:window-y="344"
+     inkscape:window-x="299"
+     inkscape:window-y="52"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata5">
@@ -57,26 +98,26 @@
      transform="translate(0,-271.59998)">
     <g
        id="g1068"
-       style="fill:#a3be8c;fill-opacity:1"
+       style="fill:url(#linearGradient1109);fill-opacity:1"
        transform="matrix(0.58450462,0,0,0.58450462,-5.7551937,168.63618)">
       <g
-         style="fill:#a3be8c;fill-opacity:1;stroke:none"
+         style="fill:url(#linearGradient1109);fill-opacity:1;stroke:none"
          transform="matrix(0.22163909,0,0,0.22163909,-7.7510456,130.86817)"
          id="g4676">
         <path
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccccccccccccccccsccccc"
            d="m 170.64172,390.24714 c -36.45889,0 -68.09809,-27.63927 -68.09809,-64.06549 l -0.0327,-44.22927 V 270.67393 H 79.39629 v -56.19662 l 97.47493,0.45904 30.49168,0.0656 c 36.49165,0 68.09809,27.60639 68.09809,64.0653 V 390.24713 H 170.64178 v 0 0 z m 89.96675,-29.82397 c 0,-24.22032 0,-81.35591 0,-81.35591 0,-27.18003 -23.83589,-49.21283 -53.24561,-49.21283 h -30.52444 v -0.0656 L 94.28144,229.4281 v 26.39336 c 0,0 3.3159,0 9.24803,0 6.27863,0 13.83376,5.90029 13.83376,14.55878 l 0.0656,55.76887 c 0,27.18005 23.836,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43528,-5.88872 17.43528,-14.93876 z"
-           style="display:inline;overflow:visible;visibility:visible;fill:#a3be8c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12712526;marker:none;enable-background:accumulate"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1111);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12712526;marker:none;enable-background:accumulate"
            id="path4210-8-3-3" />
       </g>
       <g
-         style="fill:#a3be8c;fill-opacity:1"
+         style="fill:url(#linearGradient1109);fill-opacity:1"
          id="layer3-2-5-2-5"
          inkscape:label="Layer 1"
          transform="matrix(0.11356117,0,0,0.11356117,12.684076,174.29676)">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#a3be8c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1433);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-6-9-2-6"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-neon.svg
+++ b/src/apps/scalable/linuxmint-logo-neon.svg
@@ -11,13 +11,36 @@
    sodipodi:docname="linuxmint-logo-neon.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1265">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop1261" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop1263" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1265"
+       id="linearGradient1267"
+       x1="194.61417"
+       y1="91.593979"
+       x2="195.0423"
+       y2="323.16132"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -25,19 +48,19 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="-3.5714286"
-     inkscape:cy="45.625"
+     inkscape:zoom="6.2249055"
+     inkscape:cx="32.369969"
+     inkscape:cy="46.105118"
      inkscape:document-units="px"
      inkscape:current-layer="layer3-2-5-2-27"
      showgrid="false"
      inkscape:pagecheckerboard="true"
      units="px"
-     inkscape:window-width="1619"
-     inkscape:window-height="945"
-     inkscape:window-x="747"
-     inkscape:window-y="344"
-     inkscape:window-maximized="0" />
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -64,7 +87,7 @@
          inkscape:connector-curvature="0"
          id="path4193-6-9-2-0"
          d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a3be8c;stroke-width:8.26592922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1267);stroke-width:8.26592922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/apps/scalable/linuxmint-logo-neon.svg
+++ b/src/apps/scalable/linuxmint-logo-neon.svg
@@ -35,10 +35,10 @@
        inkscape:collect="always"
        xlink:href="#linearGradient1265"
        id="linearGradient1267"
-       x1="194.61417"
-       y1="91.593979"
-       x2="195.0423"
-       y2="323.16132"
+       x1="194.1302"
+       y1="99.575188"
+       x2="194.00735"
+       y2="316.10852"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview

--- a/src/apps/scalable/linuxmint-logo-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-ring.svg
@@ -11,13 +11,36 @@
    sodipodi:docname="linuxmint-logo-ring.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient830">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop826" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop828" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient832"
+       x1="55.033203"
+       y1="186.93359"
+       x2="54.608212"
+       y2="297.28177"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,7 +49,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-45.892857"
+     inkscape:cx="30.714286"
      inkscape:cy="45.625"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -35,8 +58,8 @@
      units="px"
      inkscape:window-width="1619"
      inkscape:window-height="945"
-     inkscape:window-x="747"
-     inkscape:window-y="344"
+     inkscape:window-x="299"
+     inkscape:window-y="52"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata5">
@@ -59,19 +82,19 @@
        transform="matrix(0.23076977,0,0,0.23076977,-6.0212868e-8,228.46136)"
        id="layer1-6-7"
        inkscape:label="Calque 1"
-       style="fill:#a3be8c;fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-opacity:1">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#a3be8c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
          id="path1374-2-6"
          inkscape:connector-curvature="0" />
       <g
-         style="fill:#a3be8c;fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-opacity:1"
          id="layer3-9-56"
          inkscape:label="Layer 1"
          transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#a3be8c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-1-9"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-ring.svg
@@ -40,6 +40,15 @@
        x2="54.608212"
        y2="297.28177"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient1022"
+       gradientUnits="userSpaceOnUse"
+       x1="191.99951"
+       y1="0.0010204725"
+       x2="193.16556"
+       y2="414.55231" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -94,7 +103,7 @@
          inkscape:label="Layer 1"
          transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1022);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-1-9"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-simple.svg
+++ b/src/apps/scalable/linuxmint-logo-simple.svg
@@ -35,10 +35,10 @@
        inkscape:collect="always"
        xlink:href="#linearGradient854"
        id="linearGradient856"
-       x1="194.05339"
-       y1="99.882385"
-       x2="193.15675"
-       y2="315.49734"
+       x1="192.43761"
+       y1="103.23778"
+       x2="192.53743"
+       y2="311.3898"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview

--- a/src/apps/scalable/linuxmint-logo-simple.svg
+++ b/src/apps/scalable/linuxmint-logo-simple.svg
@@ -11,13 +11,36 @@
    sodipodi:docname="linuxmint-logo-simple.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs2" />
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient854">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop850" />
+      <stop
+         style="stop-color:#a3be8c;stop-opacity:1"
+         offset="1"
+         id="stop852" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient854"
+       id="linearGradient856"
+       x1="194.05339"
+       y1="99.882385"
+       x2="193.15675"
+       y2="315.49734"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -26,7 +49,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6"
-     inkscape:cx="-30.714286"
+     inkscape:cx="29.464286"
      inkscape:cy="40.625"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -35,8 +58,8 @@
      units="px"
      inkscape:window-width="1619"
      inkscape:window-height="945"
-     inkscape:window-x="431"
-     inkscape:window-y="88"
+     inkscape:window-x="299"
+     inkscape:window-y="52"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata5">
@@ -59,12 +82,12 @@
        transform="matrix(0.11339286,0,0,0.11811756,-9.0714283,259.73153)"
        inkscape:label="Layer 1"
        id="layer3-2-5-2-8"
-       style="fill:#a3be8c;fill-opacity:1">
+       style="fill:url(#linearGradient856);fill-opacity:1">
       <path
          inkscape:connector-curvature="0"
          id="path4193-6-9-2-9"
          d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#a3be8c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient856);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/apps/scalable/mintwelcome.svg
+++ b/src/apps/scalable/mintwelcome.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   version="1.1"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
+   sodipodi:docname="template-green.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.921875"
+     inkscape:cx="32"
+     inkscape:cy="30.645707"
+     inkscape:window-width="1920"
+     inkscape:window-height="998"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg20" />
+  <defs
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
+    <linearGradient
+       id="linearGradient862"
+       x1="8.355"
+       x2="8.355"
+       y1="16.007"
+       y2=".79375"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#a3be8c"
+         offset="0"
+         id="stop5" />
+      <stop
+         stop-color="#8fbcbb"
+         offset="1"
+         id="stop7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient832"
+       x1="380.38474"
+       y1="368.14767"
+       x2="403.13632"
+       y2="368.86572"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient830">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop826" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop828" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient861"
+       gradientUnits="userSpaceOnUse"
+       x1="196.842"
+       y1="31.418701"
+       x2="193.14655"
+       y2="383.39557" />
+  </defs>
+  <g
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       transform="matrix(.99138 0 0 1 .072989 0)"
+       x=".79375"
+       y="1.0171"
+       width="15.346"
+       height="15.346"
+       rx="3.0526"
+       ry="3.0526"
+       fill="#2e3440"
+       filter="url(#filter1178)"
+       opacity=".2"
+       stroke-width="1.2489"
+       style="mix-blend-mode:normal"
+       id="rect12" />
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient862)"
+       stroke-width="1.2274"
+       id="rect14" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
+  </g>
+  <g
+     style="fill:url(#linearGradient832);fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
+     id="layer3"
+     inkscape:label="Layer 1"
+     transform="matrix(0.04805646,0,0,0.04972446,-0.76034032,-1.8761877)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4193"
+       d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient861);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+</svg>


### PR DESCRIPTION
- mintwelcome by using the green template and centering the logo
- Changed colors of the Linux Mint logos according to linear gradients from green and white template with a very pleasing result :-). 
The form stayed unchanged as it came from hicolor. 
With a template for transparent backgrounds, I can try to reimplement them in a better way. 
It might be trivial, but can you provide such a template, please? It would be very helpful to have all standard linear gradients from the other templates present in it already vertically aligned.