### PR TITLE
Reimplementation of linuxmint logos

### DIFF
--- a/src/apps/scalable/linuxmint-logo-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-badge.svg
@@ -1,36 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-badge.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient828">
-      <stop
-         style="stop-color:#8fbcbb;stop-opacity:1"
-         offset="0"
-         id="stop930" />
-      <stop
-         style="stop-color:#a3be8c;stop-opacity:1"
-         offset="1"
-         id="stop932" />
-    </linearGradient>
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient828"
@@ -39,56 +51,49 @@
        y1="291.69141"
        x2="262.86871"
        y2="375.27399"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20328018,0,0,0.20328018,-45.042842,-59.295085)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient828">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop930" />
+      <stop
+         style="stop-color:#97b67c;stop-opacity:1"
+         offset="1"
+         id="stop932" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.2"
-     inkscape:cx="51.830357"
-     inkscape:cy="61.607143"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1-7-0"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="998"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
-    <g
-       transform="matrix(0.27272921,0,0,0.27272921,4.1688906e-5,215.99968)"
-       id="layer1-7-0"
-       inkscape:label="Calque 1"
-       style="fill:#87cf3e;fill-opacity:1;opacity:1">
-      <path
-         style="opacity:1;fill:url(#linearGradient830);fill-opacity:1;stroke:none;stroke-width:5.47888851;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 263.23047,291.69141 a 41.649708,41.649708 0 0 0 -41.65039,41.65039 41.649708,41.649708 0 0 0 41.65039,41.64843 41.649708,41.649708 0 0 0 41.64844,-41.64843 41.649708,41.649708 0 0 0 -41.64844,-41.65039 z m -26.50586,17.03906 h 7.57422 v 34.07617 c 0,4.22712 3.34514,7.57422 7.57226,7.57422 h 22.71875 c 4.22712,0 7.57227,-3.3471 7.57227,-7.57422 V 323.875 c 0,-2.13599 -1.65113,-3.78516 -3.78711,-3.78516 -2.13598,0 -3.78516,1.64917 -3.78516,3.78516 v 18.93164 h -7.57422 V 323.875 c 10e-6,-2.13599 -1.64917,-3.78516 -3.78515,-3.78516 -2.13599,0 -3.78711,1.64917 -3.78711,3.78516 v 18.93164 h -7.57227 V 323.875 c 0,-6.22856 5.13082,-11.35938 11.35938,-11.35938 2.90978,10e-6 5.55293,1.15026 7.57226,2.97852 2.01934,-1.82826 4.66249,-2.97852 7.57227,-2.97852 6.22856,10e-6 11.35938,5.13082 11.35938,11.35938 v 18.93164 c -10e-6,8.3197 -6.82484,15.14648 -15.14454,15.14648 h -22.71875 c -8.31969,0 -15.14648,-6.82678 -15.14648,-15.14648 z"
-         transform="matrix(1.118055,0,0,1.118055,-247.73887,-122.26071)"
-         id="path1374-3"
-         inkscape:connector-curvature="0" />
-    </g>
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient828)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
+    <path
+       style="fill:url(#linearGradient830);fill-opacity:1;stroke:none;stroke-width:1.11375;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.4666984,1.25e-6 A 8.4665603,8.4665603 0 0 0 2.4999998e-7,8.4666999 8.4665603,8.4665603 0 0 0 8.4666984,16.932999 8.4665603,8.4665603 0 0 0 16.933,8.4666999 8.4665603,8.4665603 0 0 0 8.4666984,1.25e-6 Z M 3.0785832,3.4637044 h 1.5396891 v 6.9270106 c 0,0.859288 0.68,1.539687 1.53929,1.539687 h 4.6182707 c 0.85929,0 1.539292,-0.680399 1.539292,-1.539687 V 6.5422867 c 0,-0.4342041 -0.335642,-0.7694481 -0.769845,-0.7694481 -0.4342,0 -0.769447,0.335244 -0.769447,0.7694481 V 10.390715 H 9.2361447 V 6.5422867 c 2e-6,-0.4342041 -0.3352431,-0.7694481 -0.7694463,-0.7694481 -0.4342032,0 -0.769844,0.335244 -0.769844,0.7694481 V 10.390715 H 6.1575623 V 6.5422867 c 0,-1.2661422 1.0429938,-2.3091364 2.3091361,-2.3091364 0.5915013,2.1e-6 1.1288003,0.2338254 1.5392906,0.6054744 0.410492,-0.371649 0.947792,-0.6054744 1.539291,-0.6054744 1.266144,2.1e-6 2.309137,1.0429942 2.309137,2.3091364 v 3.8484283 c -10e-7,1.691229 -1.387355,3.078977 -3.078584,3.078977 H 6.1575623 c -1.6912282,0 -3.0789791,-1.387748 -3.0789791,-3.078977 z"
+       id="path1374-3"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/src/apps/scalable/linuxmint-logo-filled-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-badge.svg
@@ -1,24 +1,58 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-filled-badge.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1060"
+       id="linearGradient1062"
+       x1="47.077255"
+       y1="203.89368"
+       x2="46.15699"
+       y2="296.6377"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1818146,0,0,0.1818146,4.7437134e-7,-37.065933)" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient1060">
@@ -46,80 +80,86 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient830"
-       id="linearGradient832"
+       id="linearGradient892"
+       gradientUnits="userSpaceOnUse"
        x1="196.842"
        y1="31.418701"
        x2="193.14655"
-       y2="383.39557"
-       gradientUnits="userSpaceOnUse" />
+       y2="383.39557" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient1060"
-       id="linearGradient1062"
-       x1="47.077255"
-       y1="203.89368"
-       x2="46.15699"
-       y2="296.6377"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient830"
+       id="linearGradient894"
+       gradientUnits="userSpaceOnUse"
+       x1="196.842"
+       y1="31.418701"
+       x2="193.14655"
+       y2="383.39557" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter934"
+       x="-0.072321429"
+       y="-0.077884615"
+       width="1.1446429"
+       height="1.1557692">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="6.75"
+         id="feGaussianBlur936" />
+    </filter>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="1.6964286"
-     inkscape:cy="40.535714"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1-0"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="998"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
+    <circle
+       r="8.4665003"
+       cy="8.4665003"
+       cx="8.4665003"
+       id="path1374-6"
+       style="fill:url(#linearGradient1062);fill-opacity:1;stroke:none;stroke-width:1.11374;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       transform="matrix(0.27272728,0,0,0.27272728,-6.1234151e-8,215.99998)"
-       id="layer1-0"
-       inkscape:label="Calque 1">
-      <circle
-         r="46.566666"
-         cy="250.43332"
-         cx="46.566666"
-         id="path1374-6"
-         style="opacity:1;fill:url(#linearGradient1062);fill-opacity:1;stroke:none;stroke-width:6.12569904;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <g
-         style="stroke:#ffffff;stroke-opacity:1;fill:url(#linearGradient832);fill-opacity:1"
-         id="layer3"
-         inkscape:label="Layer 1"
-         transform="matrix(0.26458333,0,0,0.26458333,-4.2333326,195.39998)">
-        <path
-           inkscape:connector-curvature="0"
-           id="path4193"
-           d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-      </g>
+       style="fill:#2e3440;fill-opacity:1;stroke:#ffffff;stroke-opacity:1;filter:url(#filter934);opacity:0.318"
+       id="layer3"
+       inkscape:label="Layer 1"
+       transform="matrix(0.04810511,0,0,0.04810511,-0.76968112,-1.5393629)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4193"
+         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#2e3440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+    <g
+       style="fill:url(#linearGradient894);fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
+       id="layer3-7"
+       inkscape:label="Layer 1"
+       transform="matrix(0.04810511,0,0,0.04810511,-0.76968112,-1.5393629)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4193-5"
+         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient892);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
@@ -1,36 +1,86 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-filled-leaf-badge.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
+     id="defs10">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient838">
+       id="linearGradient969">
       <stop
          style="stop-color:#d8dee9;stop-opacity:1"
          offset="0"
-         id="stop834" />
+         id="stop965" />
       <stop
          style="stop-color:#eceff4;stop-opacity:1"
          offset="1"
-         id="stop836" />
+         id="stop967" />
     </linearGradient>
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
+    <linearGradient
+       id="linearGradient1340"
+       x1="8.355"
+       x2="8.3996"
+       y1="16.007"
+       y2=".79375"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#d8dee9"
+         offset="0"
+         id="stop5" />
+      <stop
+         stop-color="#eceff4"
+         offset="1"
+         id="stop7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient830"
+       id="linearGradient832"
+       x1="496.48831"
+       y1="788.59967"
+       x2="497.19086"
+       y2="938.95441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10099008,0,0,0.10099008,-41.847171,-78.708744)" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient830">
@@ -45,80 +95,98 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient830"
-       id="linearGradient832"
-       x1="496.48831"
-       y1="788.59967"
-       x2="497.19086"
-       y2="938.95441"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient838">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop834" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop836" />
+    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient838"
-       id="linearGradient840"
+       id="linearGradient840-3"
        x1="178.14952"
        y1="47.734074"
        x2="177.79837"
        y2="371.38623"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient969"
+       id="linearGradient1094"
+       gradientUnits="userSpaceOnUse"
+       x1="178.14952"
+       y1="47.734074"
+       x2="177.79837"
+       y2="371.38623" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1134"
+       x="-0.072321429"
+       y="-0.077884615"
+       width="1.1446429"
+       height="1.1557692">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="6.75"
+         id="feGaussianBlur1136" />
+    </filter>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="24.196429"
-     inkscape:cy="40.178571"
-     inkscape:document-units="px"
-     inkscape:current-layer="g1214"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="998"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
+    <path
+       id="rect1013-2"
+       d="M 0,0.87636625 V 5.7296098 h 1.9965264 v 0.9740018 l 0.00257,3.8198714 c 0,3.145946 2.7327127,5.533151 5.8814883,5.533151 H 16.933 V 6.4544893 c 0,-3.1487756 -2.729687,-5.53275635 -5.881291,-5.53275635 l -2.6334343,-0.00592 z"
+       style="fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-width:0.664515;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
     <g
-       id="g1214"
-       transform="matrix(0.57255348,0,0,0.57255348,-62.771996,153.53453)">
+       id="layer3-2-3-6"
+       inkscape:label="Layer 1"
+       transform="matrix(0.04639497,0,0,0.04639497,0.6842723,-1.1836538)"
+       style="fill:#2e3440;fill-opacity:1;filter:url(#filter1134);opacity:0.318">
       <path
-         id="rect1013-2"
-         transform="scale(0.26458333)"
-         d="m 414.36914,788.04883 v 48.05664 h 19.76953 V 845.75 l 0.0254,37.82422 c 0,31.15105 27.05922,54.78906 58.23828,54.78906 h 89.63672 V 843.2832 c 0,-31.17906 -27.02926,-54.78515 -58.23633,-54.78515 l -26.07617,-0.0586 z"
-         style="opacity:1;fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-width:6.58000278;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#2e3440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+         id="path4193-6-7-1"
          inkscape:connector-curvature="0" />
-      <g
-         id="layer3-2-3-6"
-         inkscape:label="Layer 1"
-         transform="matrix(0.12154991,0,0,0.12154991,111.42789,203.16749)"
-         style="fill:url(#linearGradient840);fill-opacity:1">
-        <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient840);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-           d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-           id="path4193-6-7-1"
-           inkscape:connector-curvature="0" />
-      </g>
+    </g>
+    <g
+       id="layer3-2-3-6-3"
+       inkscape:label="Layer 1"
+       transform="matrix(0.04639497,0,0,0.04639497,0.6842723,-1.1836538)"
+       style="fill:url(#linearGradient840-3);fill-opacity:1">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+         id="path4193-6-7-1-5"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>

--- a/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf-badge.svg
@@ -32,18 +32,6 @@
      inkscape:current-layer="g18" />
   <defs
      id="defs10">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient969">
-      <stop
-         style="stop-color:#d8dee9;stop-opacity:1"
-         offset="0"
-         id="stop965" />
-      <stop
-         style="stop-color:#eceff4;stop-opacity:1"
-         offset="1"
-         id="stop967" />
-    </linearGradient>
     <filter
        id="filter1178"
        x="-0.047999482"
@@ -55,22 +43,6 @@
          stdDeviation="0.30691668"
          id="feGaussianBlur2" />
     </filter>
-    <linearGradient
-       id="linearGradient1340"
-       x1="8.355"
-       x2="8.3996"
-       y1="16.007"
-       y2=".79375"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         stop-color="#d8dee9"
-         offset="0"
-         id="stop5" />
-      <stop
-         stop-color="#eceff4"
-         offset="1"
-         id="stop7" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient830"
@@ -116,7 +88,7 @@
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient969"
+       xlink:href="#linearGradient838"
        id="linearGradient1094"
        gradientUnits="userSpaceOnUse"
        x1="178.14952"
@@ -148,7 +120,7 @@
        height="15.081"
        rx="3"
        ry="3"
-       fill="url(#linearGradient1340)"
+       fill="url(#linearGradient838)"
        stroke-width="1.2274"
        id="rect14"
        style="fill:none;fill-opacity:1" />

--- a/src/apps/scalable/linuxmint-logo-filled-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf.svg
@@ -1,36 +1,73 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-filled-leaf.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
+    <linearGradient
+       id="linearGradient1340"
+       x1="8.355"
+       x2="8.3996"
+       y1="16.007"
+       y2=".79375"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#d8dee9"
+         offset="0"
+         id="stop5" />
+      <stop
+         stop-color="#eceff4"
+         offset="1"
+         id="stop7" />
+    </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient936">
-      <stop
-         style="stop-color:#d8dee9;stop-opacity:1"
-         offset="0"
-         id="stop932" />
-      <stop
-         style="stop-color:#eceff4;stop-opacity:1"
-         offset="1"
-         id="stop934" />
-    </linearGradient>
+       xlink:href="#linearGradient852"
+       id="linearGradient854"
+       x1="577.97504"
+       y1="496.07022"
+       x2="577.77179"
+       y2="670.24707"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient852">
@@ -45,15 +82,6 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient852"
-       id="linearGradient854"
-       x1="577.97504"
-       y1="496.07022"
-       x2="577.77179"
-       y2="670.24707"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient936"
        id="linearGradient938"
        x1="590.57263"
@@ -63,6 +91,18 @@
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
+       id="linearGradient936">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop932" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop934" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient936"
        id="linearGradient847"
        x1="155.38577"
@@ -70,77 +110,69 @@
        x2="153.88199"
        y2="382.81619"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient936"
+       id="linearGradient1047"
+       gradientUnits="userSpaceOnUse"
+       x1="155.38577"
+       y1="33.811779"
+       x2="153.88199"
+       y2="382.81619" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="-0.089285714"
-     inkscape:cy="40.535714"
-     inkscape:document-units="px"
-     inkscape:current-layer="g1108"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="998"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
     <g
-       id="g1108"
-       transform="matrix(0.23966525,0,0,0.23966525,10.873397,207.99153)">
+       transform="matrix(0.08636436,0,0,0.08636436,-42.018533,-41.828837)"
+       id="g4824-3-4-8">
       <g
-         transform="matrix(0.54054181,0,0,0.54054181,-308.35691,3.6048501)"
-         id="g4824-3-4-8">
-        <g
-           id="g5159">
-          <path
-             style="display:inline;opacity:1;fill:url(#linearGradient854);fill-opacity:1;fill-rule:evenodd;stroke-width:1.12712526"
-             d="m 671.90956,642.97352 c 0,-25.20809 0,-84.67388 0,-84.67388 0,-28.28854 -24.808,-51.21991 -55.41715,-51.21991 h -31.76933 v -0.0683 L 498.79913,506.636 v 30.8947 c 0,0 7.01578,0 13.18985,0 9.20682,0 10.8333,6.35563 10.8333,15.15255 l 0.0683,54.61836 c 0,28.28856 24.8081,51.21988 55.38309,51.21988 h 75.48956 c 9.67782,0 18.14635,-6.12887 18.14635,-15.548 z"
-             id="path2576-0-3-7-4-8"
-             sodipodi:nodetypes="cccccccsccccc"
-             inkscape:connector-curvature="0" />
-          <path
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccccccccccccccccccsccccc"
-             d="m 577.77171,670.2471 c -36.45888,0 -68.09808,-27.63927 -68.09808,-64.06549 l -0.0327,-44.22927 V 550.67389 H 486.5263 v -56.19662 l 97.47492,0.45904 30.49168,0.0656 c 36.49165,0 68.09808,27.60638 68.09808,64.0653 V 670.24709 H 577.77177 v 0 0 z m 89.96674,-29.82397 c 0,-24.22031 0,-81.35591 0,-81.35591 0,-27.18004 -23.83588,-49.21283 -53.2456,-49.21283 h -30.52444 v -0.0656 l -82.55696,-0.36074 v 26.39336 c 0,0 3.31589,0 9.24802,0 6.27863,0 13.83375,5.9003 13.83375,14.55879 l 0.0656,55.76887 c 0,27.18005 23.83599,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43527,-5.88872 17.43527,-14.93876 z"
-             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient938);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12712526;marker:none;enable-background:accumulate"
-             id="path4210-8-6-5-7-3" />
-        </g>
-      </g>
-      <g
-         style="fill:url(#linearGradient847);fill-opacity:1"
-         id="layer3-2-5-2-2"
-         inkscape:label="Layer 1"
-         transform="matrix(0.27212591,0,0,0.27212591,-37.922389,261.72722)">
+         id="g5159">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient847);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-           d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-           id="path4193-6-9-2-91"
+           style="display:inline;opacity:1;fill:url(#linearGradient854);fill-opacity:1;fill-rule:evenodd;stroke-width:1.12713"
+           d="m 671.90956,642.97352 c 0,-25.20809 0,-84.67388 0,-84.67388 0,-28.28854 -24.808,-51.21991 -55.41715,-51.21991 h -31.76933 v -0.0683 L 498.79913,506.636 v 30.8947 c 0,0 7.01578,0 13.18985,0 9.20682,0 10.8333,6.35563 10.8333,15.15255 l 0.0683,54.61836 c 0,28.28856 24.8081,51.21988 55.38309,51.21988 h 75.48956 c 9.67782,0 18.14635,-6.12887 18.14635,-15.548 z"
+           id="path2576-0-3-7-4-8"
+           sodipodi:nodetypes="cccccccsccccc"
            inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccsccccc"
+           d="m 577.77171,670.2471 c -36.45888,0 -68.09808,-27.63927 -68.09808,-64.06549 l -0.0327,-44.22927 V 550.67389 H 486.5263 v -56.19662 l 97.47492,0.45904 30.49168,0.0656 c 36.49165,0 68.09808,27.60638 68.09808,64.0653 V 670.24709 H 577.77177 v 0 0 z m 89.96674,-29.82397 c 0,-24.22031 0,-81.35591 0,-81.35591 0,-27.18004 -23.83588,-49.21283 -53.2456,-49.21283 h -30.52444 v -0.0656 l -82.55696,-0.36074 v 26.39336 c 0,0 3.31589,0 9.24802,0 6.27863,0 13.83375,5.9003 13.83375,14.55879 l 0.0656,55.76887 c 0,27.18005 23.83599,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43527,-5.88872 17.43527,-14.93876 z"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient938);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12713;marker:none;enable-background:accumulate"
+           id="path4210-8-6-5-7-3" />
       </g>
+    </g>
+    <g
+       style="fill:url(#linearGradient847);fill-opacity:1"
+       id="layer3-2-5-2-2"
+       inkscape:label="Layer 1"
+       transform="matrix(0.04347856,0,0,0.04347856,1.1897854,-0.57704048)">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1047);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+         id="path4193-6-9-2-91"
+         inkscape:connector-curvature="0" />
     </g>
   </g>
 </svg>

--- a/src/apps/scalable/linuxmint-logo-filled-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-leaf.svg
@@ -44,22 +44,6 @@
          id="feGaussianBlur2" />
     </filter>
     <linearGradient
-       id="linearGradient1340"
-       x1="8.355"
-       x2="8.3996"
-       y1="16.007"
-       y2=".79375"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         stop-color="#d8dee9"
-         offset="0"
-         id="stop5" />
-      <stop
-         stop-color="#eceff4"
-         offset="1"
-         id="stop7" />
-    </linearGradient>
-    <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient852"
        id="linearGradient854"
@@ -82,15 +66,6 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient936"
-       id="linearGradient938"
-       x1="590.57263"
-       y1="494.61368"
-       x2="591.80859"
-       y2="670.54828"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
        id="linearGradient936">
       <stop
          style="stop-color:#d8dee9;stop-opacity:1"
@@ -104,7 +79,30 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient936"
-       id="linearGradient847"
+       id="linearGradient938-2"
+       x1="590.57263"
+       y1="494.61368"
+       x2="591.80859"
+       y2="670.54828"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4e-6)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1170"
+       x="-0.071118336"
+       y="-0.079329848"
+       width="1.1422367"
+       height="1.1586597">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="5.8099142"
+         id="feGaussianBlur1172" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient936"
+       id="linearGradient847-7"
        x1="155.38577"
        y1="33.811779"
        x2="153.88199"
@@ -113,12 +111,25 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient936"
-       id="linearGradient1047"
+       id="linearGradient1263"
        gradientUnits="userSpaceOnUse"
        x1="155.38577"
        y1="33.811779"
        x2="153.88199"
        y2="382.81619" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1303"
+       x="-0.072321429"
+       y="-0.077884615"
+       width="1.1446429"
+       height="1.1557692">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="6.75"
+         id="feGaussianBlur1305" />
+    </filter>
   </defs>
   <g
      stroke-linecap="round"
@@ -131,7 +142,7 @@
        height="15.081"
        rx="3"
        ry="3"
-       fill="url(#linearGradient1340)"
+       fill="url(#linearGradient852)"
        stroke-width="1.2274"
        id="rect14"
        style="fill:none;fill-opacity:1" />
@@ -159,19 +170,36 @@
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccccccccccccccccsccccc"
            d="m 577.77171,670.2471 c -36.45888,0 -68.09808,-27.63927 -68.09808,-64.06549 l -0.0327,-44.22927 V 550.67389 H 486.5263 v -56.19662 l 97.47492,0.45904 30.49168,0.0656 c 36.49165,0 68.09808,27.60638 68.09808,64.0653 V 670.24709 H 577.77177 v 0 0 z m 89.96674,-29.82397 c 0,-24.22031 0,-81.35591 0,-81.35591 0,-27.18004 -23.83588,-49.21283 -53.2456,-49.21283 h -30.52444 v -0.0656 l -82.55696,-0.36074 v 26.39336 c 0,0 3.31589,0 9.24802,0 6.27863,0 13.83375,5.9003 13.83375,14.55879 l 0.0656,55.76887 c 0,27.18005 23.83599,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43527,-5.88872 17.43527,-14.93876 z"
-           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient938);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12713;marker:none;enable-background:accumulate"
+           style="display:inline;overflow:visible;visibility:visible;fill:#2e3440;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12713;marker:none;enable-background:accumulate;filter:url(#filter1170);opacity:0.318"
            id="path4210-8-6-5-7-3" />
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccsccccc"
+           d="m 577.77171,670.24711 c -36.45888,0 -68.09808,-27.63928 -68.09808,-64.06549 l -0.0327,-44.22927 V 550.67389 H 486.5263 v -56.19661 l 97.47492,0.45904 30.49168,0.0656 c 36.49165,0 68.09808,27.60638 68.09808,64.0653 V 670.24709 H 577.77177 v 0 0 z m 89.96674,-29.82398 c 0,-24.22031 0,-81.35591 0,-81.35591 0,-27.18003 -23.83588,-49.21282 -53.2456,-49.21282 h -30.52444 v -0.0656 l -82.55696,-0.36075 v 26.39336 c 0,0 3.31589,0 9.24802,0 6.27863,0 13.83375,5.9003 13.83375,14.5588 l 0.0656,55.76887 c 0,27.18005 23.83599,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43527,-5.88873 17.43527,-14.93876 z"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient938-2);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12713;marker:none;enable-background:accumulate"
+           id="path4210-8-6-5-7-3-3" />
       </g>
     </g>
     <g
-       style="fill:url(#linearGradient847);fill-opacity:1"
+       style="fill:#2e3440;fill-opacity:1;filter:url(#filter1303);opacity:0.318"
        id="layer3-2-5-2-2"
        inkscape:label="Layer 1"
        transform="matrix(0.04347856,0,0,0.04347856,1.1897854,-0.57704048)">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1047);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#2e3440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
          id="path4193-6-9-2-91"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="fill:url(#linearGradient847-7);fill-opacity:1"
+       id="layer3-2-5-2-2-2"
+       inkscape:label="Layer 1"
+       transform="matrix(0.04347856,0,0,0.04347856,1.1897854,-0.57704048)">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1263);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+         id="path4193-6-9-2-91-8"
          inkscape:connector-curvature="0" />
     </g>
   </g>

--- a/src/apps/scalable/linuxmint-logo-filled-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-ring.svg
@@ -1,36 +1,74 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-filled-ring.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
+    <linearGradient
+       id="linearGradient1340"
+       x1="8.355"
+       x2="8.3996"
+       y1="16.007"
+       y2=".79375"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#d8dee9"
+         offset="0"
+         id="stop5" />
+      <stop
+         stop-color="#eceff4"
+         offset="1"
+         id="stop7" />
+    </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient841">
-      <stop
-         style="stop-color:#d8dee9;stop-opacity:1"
-         offset="0"
-         id="stop837" />
-      <stop
-         style="stop-color:#eceff4;stop-opacity:1"
-         offset="1"
-         id="stop839" />
-    </linearGradient>
+       xlink:href="#linearGradient832"
+       id="linearGradient834"
+       x1="177.35075"
+       y1="243.33424"
+       x2="177.1613"
+       y2="265.99271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74695146,0,0,0.74695146,-123.89727,-181.79743)" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient832">
@@ -45,15 +83,6 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient832"
-       id="linearGradient834"
-       x1="177.35075"
-       y1="243.33424"
-       x2="177.1613"
-       y2="265.99271"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient841"
        id="linearGradient1406"
        gradientUnits="userSpaceOnUse"
@@ -61,75 +90,97 @@
        y1="186.93359"
        x2="55.675446"
        y2="296.95972" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient841">
+      <stop
+         style="stop-color:#d8dee9;stop-opacity:1"
+         offset="0"
+         id="stop837" />
+      <stop
+         style="stop-color:#eceff4;stop-opacity:1"
+         offset="1"
+         id="stop839" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient841"
+       id="linearGradient1130"
+       gradientUnits="userSpaceOnUse"
+       x1="55.033203"
+       y1="186.93359"
+       x2="55.675446"
+       y2="296.95972" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient841"
+       id="linearGradient1132"
+       gradientUnits="userSpaceOnUse"
+       x1="191.99951"
+       y1="0.0010204725"
+       x2="191.78033"
+       y2="416.02927" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient841"
+       id="linearGradient1134"
+       gradientUnits="userSpaceOnUse"
+       x1="55.033203"
+       y1="186.93359"
+       x2="55.675446"
+       y2="296.95972" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="13.839286"
-     inkscape:cy="44.285714"
-     inkscape:document-units="px"
-     inkscape:current-layer="g909"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="998"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
+    <ellipse
+       ry="7.4464502"
+       rx="7.3018599"
+       cy="8.4665003"
+       cx="8.4665003"
+       id="path1393-5"
+       style="fill:url(#linearGradient834);fill-opacity:1;stroke:none;stroke-width:0.76508;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       id="g909"
-       transform="matrix(1.1204493,0,0,1.1204493,-186.01252,-1.043702)">
-      <ellipse
-         ry="9.9691219"
-         rx="9.775548"
-         cy="254.72061"
-         cx="177.20531"
-         id="path1393-5"
-         style="opacity:1;fill:url(#linearGradient834);fill-opacity:1;stroke:none;stroke-width:1.02427185;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:url(#linearGradient1406);fill-opacity:1;stroke:none;stroke-opacity:1"
+       inkscape:label="Calque 1"
+       id="layer1-6-7-4"
+       transform="matrix(0.15384348,0,0,0.15384348,2.272466e-7,-28.758514)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1374-2-6-7"
+         d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1130);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17233;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <g
-         style="fill:url(#linearGradient1406);fill-opacity:1;stroke:none;stroke-opacity:1"
-         inkscape:label="Calque 1"
-         id="layer1-6-7-4"
-         transform="matrix(0.20596182,0,0,0.20596182,166.01601,204.83306)">
+         transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)"
+         inkscape:label="Layer 1"
+         id="layer3-9-56-4"
+         style="fill:url(#linearGradient1134);fill-opacity:1;stroke:none;stroke-opacity:1">
         <path
            inkscape:connector-curvature="0"
-           id="path1374-2-6-7"
-           d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1406);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-        <g
-           transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)"
-           inkscape:label="Layer 1"
-           id="layer3-9-56-4"
-           style="fill:url(#linearGradient1406);fill-opacity:1;stroke:none;stroke-opacity:1">
-          <path
-             inkscape:connector-curvature="0"
-             id="path4193-1-9-4"
-             d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1406);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-        </g>
+           id="path4193-1-9-4"
+           d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1132);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       </g>
     </g>
   </g>

--- a/src/apps/scalable/linuxmint-logo-filled-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-filled-ring.svg
@@ -29,7 +29,7 @@
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g18" />
+     inkscape:current-layer="layer1-6-7-4" />
   <defs
      id="defs10">
     <filter
@@ -43,22 +43,6 @@
          stdDeviation="0.30691668"
          id="feGaussianBlur2" />
     </filter>
-    <linearGradient
-       id="linearGradient1340"
-       x1="8.355"
-       x2="8.3996"
-       y1="16.007"
-       y2=".79375"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         stop-color="#d8dee9"
-         offset="0"
-         id="stop5" />
-      <stop
-         stop-color="#eceff4"
-         offset="1"
-         id="stop7" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient832"
@@ -105,16 +89,30 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient841"
-       id="linearGradient1130"
+       id="linearGradient877"
        gradientUnits="userSpaceOnUse"
        x1="55.033203"
        y1="186.93359"
        x2="55.675446"
-       y2="296.95972" />
+       y2="296.95972"
+       gradientTransform="translate(3e-6)" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter918"
+       x="-0.074999997"
+       y="-0.074999997"
+       width="1.15"
+       height="1.15">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="3.4395753"
+         id="feGaussianBlur920" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient841"
-       id="linearGradient1132"
+       id="linearGradient1132-6-0"
        gradientUnits="userSpaceOnUse"
        x1="191.99951"
        y1="0.0010204725"
@@ -123,12 +121,25 @@
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient841"
-       id="linearGradient1134"
+       id="linearGradient1052"
        gradientUnits="userSpaceOnUse"
-       x1="55.033203"
-       y1="186.93359"
-       x2="55.675446"
-       y2="296.95972" />
+       x1="192"
+       y1="0.00049133861"
+       x2="195.46667"
+       y2="415.17203" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1076"
+       x="-0.072321429"
+       y="-0.077884615"
+       width="1.1446429"
+       height="1.1557692">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="6.75"
+         id="feGaussianBlur1078" />
+    </filter>
   </defs>
   <g
      stroke-linecap="round"
@@ -141,7 +152,7 @@
        height="15.081"
        rx="3"
        ry="3"
-       fill="url(#linearGradient1340)"
+       fill="url(#linearGradient841)"
        stroke-width="1.2274"
        id="rect14"
        style="fill:none;fill-opacity:1" />
@@ -170,17 +181,33 @@
          inkscape:connector-curvature="0"
          id="path1374-2-6-7"
          d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1130);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17233;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.318;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#2e3440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17233;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter:url(#filter918)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1374-2-6-7-7"
+         d="m 55.033203,186.93359 c -30.33975,0 -55.0332,24.69346 -55.0332,55.03321 0,30.33975 24.69345,55.0332 55.0332,55.0332 30.33975,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693457,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.38266,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478667,45.86132 -45.861327,45.86132 -25.38265,0 -45.86133,-20.47867 -45.86133,-45.86132 0,-25.38266 20.47868,-45.86133 45.86133,-45.86133 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient877);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17233;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <g
-         transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)"
+         transform="matrix(0.26458333,0,0,0.26458333,4.233203,186.93346)"
          inkscape:label="Layer 1"
-         id="layer3-9-56-4"
-         style="fill:url(#linearGradient1134);fill-opacity:1;stroke:none;stroke-opacity:1">
+         id="layer3-9-56-4-2"
+         style="opacity:0.318;fill:#2e3440;fill-opacity:1;stroke:none;stroke-opacity:1;filter:url(#filter1076)">
         <path
            inkscape:connector-curvature="0"
-           id="path4193-1-9-4"
+           id="path4193-1-9-4-9"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1132);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#2e3440;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
+      <g
+         transform="matrix(0.26458333,0,0,0.26458333,4.233203,186.93346)"
+         inkscape:label="Layer 1"
+         id="layer3-9-56-4-2-9"
+         style="fill:url(#linearGradient1052);fill-opacity:1;stroke:none;stroke-opacity:1">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4193-1-9-4-9-3"
+           d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1132-6-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       </g>
     </g>
   </g>

--- a/src/apps/scalable/linuxmint-logo-leaf-badge.svg
+++ b/src/apps/scalable/linuxmint-logo-leaf-badge.svg
@@ -1,36 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-leaf-badge.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient827">
-      <stop
-         style="stop-color:#8fbcbb;stop-opacity:1"
-         offset="0"
-         id="stop823" />
-      <stop
-         style="stop-color:#a3be8c;stop-opacity:1"
-         offset="1"
-         id="stop825" />
-    </linearGradient>
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient827"
@@ -39,48 +51,48 @@
        y1="272.91965"
        x2="13.104102"
        y2="295.69534"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66665355,0,0,0.66665355,-9.9999999e-8,-181.06309)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient827">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop823" />
+      <stop
+         style="stop-color:#97b67c;stop-opacity:1"
+         offset="1"
+         id="stop825" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="36.785714"
-     inkscape:cy="45.267857"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1619"
-     inkscape:window-height="945"
-     inkscape:window-x="299"
-     inkscape:window-y="52"
-     inkscape:window-maximized="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
     <path
-       style="opacity:1;fill:url(#linearGradient829);fill-opacity:1;stroke:none;stroke-width:0.99678552;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -5.0000018e-8,272.91461 v 7.28019 H 2.9946537 v 1.46089 l 0.00413,5.72989 c 0,4.71899 4.0989904,8.29977 8.8222123,8.29977 H 25.4 v -14.40327 c 0,-4.72323 -4.094747,-8.29925 -8.822211,-8.29925 l -3.950152,-0.009 z M 6.6331937,277.12676 h 2.2164047 v 9.97357 c 0,1.23716 0.9792403,2.2164 2.2164076,2.2164 h 6.648696 c 1.237166,0 2.216407,-0.97924 2.216407,-2.2164 v -5.54076 c 0,-0.62514 -0.4828,-1.10846 -1.107945,-1.10846 -0.625147,0 -1.108462,0.48332 -1.108462,1.10846 v 5.54076 h -2.216405 v -5.54076 c 0,-0.62514 -0.482798,-1.10846 -1.107944,-1.10846 -0.625145,0 -1.107944,0.48332 -1.107944,1.10846 v 5.54076 h -2.216403 v -5.54076 c 0,-1.82293 1.501413,-3.32434 3.324347,-3.32434 0.851615,0 1.625398,0.33618 2.216404,0.87126 0.591009,-0.53508 1.364792,-0.87126 2.216407,-0.87126 1.822934,0 3.324348,1.50141 3.324348,3.32434 v 5.54076 c 0,2.43495 -1.997856,4.43281 -4.43281,4.43281 h -6.648696 c -2.4349563,0 -4.4328123,-1.99786 -4.4328123,-4.43281 z"
+       style="fill:url(#linearGradient829);fill-opacity:1;stroke:none;stroke-width:0.664511;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -9.9999999e-8,0.8764029 V 5.7297674 H 1.9963964 v 0.9739075 l 0.00275,3.8198511 c 0,3.145931 2.7326065,5.533071 5.8813591,5.533071 H 16.933 V 6.4546065 c 0,-3.1487581 -2.729778,-5.5327245 -5.881358,-5.5327245 l -2.6333831,-0.006 z M 4.422042,3.6844476 h 1.4775741 v 6.6489164 c 0,0.824756 0.652814,1.47757 1.4775759,1.47757 h 4.432377 c 0.824761,0 1.477576,-0.652814 1.477576,-1.47757 V 6.6395961 c 0,-0.4167518 -0.321861,-0.7389588 -0.738616,-0.7389588 -0.416756,0 -0.73896,0.322207 -0.73896,0.7389588 V 10.333364 H 10.331995 V 6.6395961 c 0,-0.4167518 -0.32186,-0.7389588 -0.738615,-0.7389588 -0.4167554,0 -0.738615,0.322207 -0.738615,0.7389588 V 10.333364 H 7.377192 V 6.6395961 c 0,-1.2152627 1.0009224,-2.216183 2.216188,-2.216183 0.567732,0 1.083577,0.2241156 1.477573,0.5808286 0.393999,-0.356713 0.909844,-0.5808286 1.477576,-0.5808286 1.215266,0 2.216188,1.0009203 2.216188,2.216183 v 3.6937679 c 0,1.623268 -1.331878,2.955148 -2.955148,2.955148 H 7.377192 c -1.6232722,0 -2.95515,-1.33188 -2.95515,-2.955148 z"
        id="rect1013"
        inkscape:connector-curvature="0" />
   </g>

--- a/src/apps/scalable/linuxmint-logo-leaf.svg
+++ b/src/apps/scalable/linuxmint-logo-leaf.svg
@@ -1,118 +1,120 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-leaf.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g1068" />
   <defs
-     id="defs2">
+     id="defs10">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient883">
+       id="linearGradient1484">
       <stop
          style="stop-color:#8fbcbb;stop-opacity:1"
          offset="0"
-         id="stop879" />
+         id="stop1480" />
       <stop
-         style="stop-color:#a3be8c;stop-opacity:1"
+         style="stop-color:#97b67c;stop-opacity:1"
          offset="1"
-         id="stop881" />
+         id="stop1482" />
     </linearGradient>
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient883"
-       id="linearGradient1109"
-       gradientUnits="userSpaceOnUse"
-       x1="30.307899"
-       y1="178.14514"
-       x2="30.069843"
-       y2="217.36218" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient883"
+       xlink:href="#linearGradient1484"
        id="linearGradient1111"
        gradientUnits="userSpaceOnUse"
-       x1="177.52783"
-       y1="204.49129"
-       x2="178.84206"
-       y2="400.20526" />
+       x1="178.54076"
+       y1="214.66336"
+       x2="178.96378"
+       y2="390.02649" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient883"
+       xlink:href="#linearGradient1484"
        id="linearGradient1433"
        gradientUnits="userSpaceOnUse"
-       x1="164.6869"
-       y1="15.429844"
+       x1="167.38435"
+       y1="17.01363"
        x2="168.62326"
        y2="398.61319" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="44.821429"
-     inkscape:cy="45.625"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1619"
-     inkscape:window-height="945"
-     inkscape:window-x="299"
-     inkscape:window-y="52"
-     inkscape:window-maximized="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
     <g
        id="g1068"
        style="fill:url(#linearGradient1109);fill-opacity:1"
-       transform="matrix(0.58450462,0,0,0.58450462,-5.7551937,168.63618)">
+       transform="matrix(0.38966208,0,0,0.38966208,-3.8367204,-68.64118)">
       <g
-         style="fill:url(#linearGradient1109);fill-opacity:1;stroke:none"
+         style="fill:url(#linearGradient1047);fill-opacity:1;stroke:none"
          transform="matrix(0.22163909,0,0,0.22163909,-7.7510456,130.86817)"
          id="g4676">
         <path
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccccccccccccccccsccccc"
            d="m 170.64172,390.24714 c -36.45889,0 -68.09809,-27.63927 -68.09809,-64.06549 l -0.0327,-44.22927 V 270.67393 H 79.39629 v -56.19662 l 97.47493,0.45904 30.49168,0.0656 c 36.49165,0 68.09809,27.60639 68.09809,64.0653 V 390.24713 H 170.64178 v 0 0 z m 89.96675,-29.82397 c 0,-24.22032 0,-81.35591 0,-81.35591 0,-27.18003 -23.83589,-49.21283 -53.24561,-49.21283 h -30.52444 v -0.0656 L 94.28144,229.4281 v 26.39336 c 0,0 3.3159,0 9.24803,0 6.27863,0 13.83376,5.90029 13.83376,14.55878 l 0.0656,55.76887 c 0,27.18005 23.836,49.21281 53.21289,49.21281 h 72.53146 c 9.29857,0 17.43528,-5.88872 17.43528,-14.93876 z"
-           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1111);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.12712526;marker:none;enable-background:accumulate"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1111);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1.12713;marker:none;enable-background:accumulate"
            id="path4210-8-3-3" />
       </g>
       <g
-         style="fill:url(#linearGradient1109);fill-opacity:1"
+         style="fill:url(#linearGradient1049);fill-opacity:1"
          id="layer3-2-5-2-5"
          inkscape:label="Layer 1"
          transform="matrix(0.11356117,0,0,0.11356117,12.684076,174.29676)">

--- a/src/apps/scalable/linuxmint-logo-neon.svg
+++ b/src/apps/scalable/linuxmint-logo-neon.svg
@@ -1,36 +1,48 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-neon.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g18" />
   <defs
-     id="defs2">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient1265">
-      <stop
-         style="stop-color:#8fbcbb;stop-opacity:1"
-         offset="0"
-         id="stop1261" />
-      <stop
-         style="stop-color:#a3be8c;stop-opacity:1"
-         offset="1"
-         id="stop1263" />
-    </linearGradient>
+     id="defs10">
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient1265"
@@ -39,55 +51,49 @@
        y1="99.575188"
        x2="194.00735"
        y2="316.10852"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0729035,0,0,0.0729035,-5.5309729,-6.6974287)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1265">
+      <stop
+         style="stop-color:#8fbcbb;stop-opacity:1"
+         offset="0"
+         id="stop1261" />
+      <stop
+         style="stop-color:#97b67c;stop-opacity:1"
+         offset="1"
+         id="stop1263" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.2249055"
-     inkscape:cx="32.369969"
-     inkscape:cy="46.105118"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer3-2-5-2-27"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="998"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
-    <g
-       transform="matrix(0.10935741,0,0,0.10935741,-8.2966227,261.55364)"
-       inkscape:label="Layer 1"
-       id="layer3-2-5-2-27"
-       style="fill:none;fill-opacity:1;stroke:#87cf3e;stroke-width:8.26592922;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <path
-         inkscape:connector-curvature="0"
-         id="path4193-6-9-2-0"
-         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1267);stroke-width:8.26592922;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    </g>
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1265)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4193-6-9-2-0"
+       d="M 0.3013075,0.8845357 V 11.38264 c 0,2.563047 2.1027768,4.665824 4.6658241,4.665824 h 6.9987364 c 2.563047,0 4.665824,-2.102777 4.665824,-4.665824 V 5.5503599 c 0,-1.9188312 -1.580538,-3.4993682 -3.499368,-3.4993682 -0.896415,0 -1.710815,0.3543256 -2.332912,0.9175591 C 10.177314,2.4053173 9.3629145,2.0509917 8.4664998,2.0509917 c -1.9188311,0 -3.4993682,1.580537 -3.4993682,3.4993682 V 11.38264 H 7.3000438 V 5.5503599 c 0,-0.6580322 0.5084239,-1.1664561 1.166456,-1.1664561 0.658032,0 1.166456,0.5084239 1.166456,1.1664561 V 11.38264 H 11.965868 V 5.5503599 c 0,-0.6580322 0.508424,-1.1664561 1.166456,-1.1664561 0.658032,0 1.166456,0.5084239 1.166456,1.1664561 V 11.38264 c 0,1.302248 -1.030664,2.332912 -2.332912,2.332912 H 4.9671316 c -1.3022482,0 -2.332912,-1.030664 -2.332912,-2.332912 V 0.8845357 Z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1267);stroke-width:0.602615;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/apps/scalable/linuxmint-logo-ring.svg
+++ b/src/apps/scalable/linuxmint-logo-ring.svg
@@ -1,109 +1,129 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-ring.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1-6-7" />
   <defs
-     id="defs2">
+     id="defs10">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient830">
+       id="linearGradient1324">
       <stop
          style="stop-color:#8fbcbb;stop-opacity:1"
          offset="0"
-         id="stop826" />
+         id="stop1320" />
       <stop
-         style="stop-color:#a3be8c;stop-opacity:1"
+         style="stop-color:#97b67c;stop-opacity:1"
          offset="1"
-         id="stop828" />
+         id="stop1322" />
     </linearGradient>
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient830"
-       id="linearGradient832"
-       x1="55.033203"
-       y1="186.93359"
-       x2="54.608212"
-       y2="297.28177"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient830"
+       xlink:href="#linearGradient1324"
        id="linearGradient1022"
        gradientUnits="userSpaceOnUse"
        x1="191.99951"
        y1="0.0010204725"
        x2="193.16556"
        y2="414.55231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1324"
+       id="linearGradient949"
+       gradientUnits="userSpaceOnUse"
+       x1="55.033203"
+       y1="186.93359"
+       x2="54.608212"
+       y2="297.28177" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1324"
+       id="linearGradient951"
+       gradientUnits="userSpaceOnUse"
+       x1="191.99951"
+       y1="0.0010204725"
+       x2="193.54784"
+       y2="415.66278" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="30.714286"
-     inkscape:cy="45.625"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1619"
-     inkscape:window-height="945"
-     inkscape:window-x="299"
-     inkscape:window-y="52"
-     inkscape:window-maximized="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1324)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
     <g
-       transform="matrix(0.23076977,0,0,0.23076977,-6.0212868e-8,228.46136)"
+       transform="matrix(0.15384348,0,0,0.15384348,2.272466e-7,-28.758514)"
        id="layer1-6-7"
        inkscape:label="Calque 1"
-       style="fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-opacity:1">
+       style="fill:url(#linearGradient832);fill-opacity:1.0;stroke:none;stroke-opacity:1">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient832);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.17232609;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient949);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:9.17233;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="M 55.033203,186.93359 C 24.693454,186.93359 0,211.62705 0,241.9668 0,272.30655 24.693454,297 55.033203,297 c 30.339749,0 55.033207,-24.69345 55.033207,-55.0332 0,-30.33975 -24.693458,-55.03321 -55.033207,-55.03321 z m 0,9.17188 c 25.382656,0 45.861327,20.47867 45.861327,45.86133 0,25.38265 -20.478671,45.86132 -45.861327,45.86132 -25.382656,0 -45.861328,-20.47867 -45.861328,-45.86132 0,-25.38266 20.478672,-45.86133 45.861328,-45.86133 z"
          id="path1374-2-6"
          inkscape:connector-curvature="0" />
       <g
-         style="fill:url(#linearGradient832);fill-opacity:1;stroke:none;stroke-opacity:1"
+         style="fill:url(#linearGradient951);fill-opacity:1;stroke:none;stroke-opacity:1"
          id="layer3-9-56"
          inkscape:label="Layer 1"
          transform="matrix(0.26458333,0,0,0.26458333,4.2333331,186.93332)">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1022);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1022);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
            id="path4193-1-9"
            inkscape:connector-curvature="0" />

--- a/src/apps/scalable/linuxmint-logo-simple.svg
+++ b/src/apps/scalable/linuxmint-logo-simple.svg
@@ -1,93 +1,110 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   width="96"
-   height="96"
-   viewBox="0 0 25.399999 25.400001"
+   width="64"
+   height="64"
    version="1.1"
-   id="svg8"
-   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
+   viewBox="0 0 16.933 16.933"
+   id="svg20"
    sodipodi:docname="linuxmint-logo-simple.svg"
+   inkscape:version="1.1.2 (1:1.1+202202050950+0a00cf5339)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview22"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="12.984375"
+     inkscape:cx="32"
+     inkscape:cy="31.961492"
+     inkscape:window-width="2560"
+     inkscape:window-height="1358"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1-6-7" />
   <defs
-     id="defs2">
+     id="defs10">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient854">
+       id="linearGradient1228">
       <stop
          style="stop-color:#8fbcbb;stop-opacity:1"
          offset="0"
-         id="stop850" />
+         id="stop1224" />
       <stop
-         style="stop-color:#a3be8c;stop-opacity:1"
+         style="stop-color:#97b67c;stop-opacity:1"
          offset="1"
-         id="stop852" />
+         id="stop1226" />
     </linearGradient>
+    <filter
+       id="filter1178"
+       x="-0.047999482"
+       y="-0.047999482"
+       width="1.095999"
+       height="1.095999"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="0.30691668"
+         id="feGaussianBlur2" />
+    </filter>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient854"
-       id="linearGradient856"
+       xlink:href="#linearGradient1228"
+       id="linearGradient1024"
+       gradientUnits="userSpaceOnUse"
        x1="192.43761"
        y1="103.23778"
        x2="192.53743"
-       y2="311.3898"
-       gradientUnits="userSpaceOnUse" />
+       y2="311.3898" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.6"
-     inkscape:cx="29.464286"
-     inkscape:cy="40.625"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     units="px"
-     inkscape:window-width="1619"
-     inkscape:window-height="945"
-     inkscape:window-x="299"
-     inkscape:window-y="52"
-     inkscape:window-maximized="0" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     inkscape:label="Calque 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-271.59998)">
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     id="g18">
+    <rect
+       x=".92604"
+       y=".92604"
+       width="15.081"
+       height="15.081"
+       rx="3"
+       ry="3"
+       fill="url(#linearGradient1340)"
+       stroke-width="1.2274"
+       id="rect14"
+       style="fill:none;fill-opacity:1" />
+    <rect
+       x=".01215"
+       y=".0060174"
+       width="16.924"
+       height="16.927"
+       fill="none"
+       opacity=".15"
+       stroke-width="1.052"
+       id="rect16" />
     <g
-       transform="matrix(0.11339286,0,0,0.11811756,-9.0714283,259.73153)"
-       inkscape:label="Layer 1"
-       id="layer3-2-5-2-8"
-       style="fill:url(#linearGradient856);fill-opacity:1">
-      <path
-         inkscape:connector-curvature="0"
-         id="path4193-6-9-2-9"
-         d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient856);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       transform="matrix(0.15384348,0,0,0.15384348,2.272466e-7,-28.758514)"
+       id="layer1-6-7"
+       inkscape:label="Calque 1"
+       style="fill:url(#linearGradient832);fill-opacity:1.0;stroke:none;stroke-opacity:1">
+      <g
+         transform="matrix(0.49136791,0,0,0.51184157,-39.309434,135.50375)"
+         inkscape:label="Layer 1"
+         id="layer3-2-5-2-8"
+         style="fill:url(#linearGradient856);fill-opacity:1.0">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4193-6-9-2-9"
+           d="m 80,104 v 144 c 0,35.15671 28.84329,64 64,64 h 96 c 35.15671,0 64,-28.84329 64,-64 v -80 c 0,-26.32015 -21.67985,-48 -48,-48 -12.29591,0 -23.46684,4.8602 -32,12.58594 C 215.46684,124.8602 204.29591,120 192,120 c -26.32015,0 -48,21.67985 -48,48 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 h 32 v -80 c 0,-9.02607 6.97393,-16 16,-16 9.02607,0 16,6.97393 16,16 v 80 c 0,17.86263 -14.13737,32 -32,32 h -96 c -17.86263,0 -32,-14.13737 -32,-32 V 104 Z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1024);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:32;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      </g>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Reimplementation as folllows:

- Use of format according to templates but fill all 64x64 as these logos are sort of symbolic
- linuxmint-logo-filled-badge, linuxmint-logo-filled-leaf, linuxmint-logo-filled-leaf-badge, linuxmint-logo-filled-ring: 
design aligned with mintwelcome
- linuxmint-logo-badge, linuxmint-logo-filled-badge, linuxmint-logo-leaf, linuxmint-logo-leaf-badge, linuxmint-logo-neon, linuxmint-logo-ring, linuxmint-logo-simple: 
color gradient changed from (nord7 - nord14) to (nord7 - aurora green) to give them a stronger appearance as they stand alone without any white