### PR TITLE
Added drop shadows to the Blender icon

### DIFF
--- a/src/apps/scalable/blender.svg
+++ b/src/apps/scalable/blender.svg
@@ -1,33 +1,193 @@
-<svg width="64" height="64" version="1.1" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg">
- <defs>
-  <filter id="filter1178" x="-.048" y="-.048" width="1.096" height="1.096" color-interpolation-filters="sRGB">
-   <feGaussianBlur stdDeviation="0.30691955"/>
-  </filter>
-  <linearGradient id="linearGradient1694" x1="48.597" x2="48.597" y1="-1.8124" y2="3.8129" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#88c0d0" offset="0"/>
-   <stop stop-color="#5e81ac" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1830" x1="48.461" x2="48.461" y1="-3.5809" y2="6.0409" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#eceff4" offset="0"/>
-   <stop stop-color="#d8dee9" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient1902" x1="176.3" x2="176.3" y1="-38.658" y2="35.521" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#d69a85" offset="0"/>
-   <stop stop-color="#cb795d" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient4554" x1="8.0262" x2="8.0262" y1="1.1559" y2="16.004" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#4c566a" offset="0"/>
-   <stop stop-color="#2e3440" offset="1"/>
-  </linearGradient>
- </defs>
- <g stroke-linecap="round" stroke-linejoin="round">
-  <rect transform="matrix(.99138 0 0 1 .072989 .1117)" x=".79375" y=".79375" width="15.346" height="15.346" rx="3.0526" ry="3.0526" fill="#2e3440" filter="url(#filter1178)" opacity=".2" stroke-width="1.2489"/>
-  <rect x=".92604" y=".92604" width="15.081" height="15.081" rx="3" ry="3" fill="url(#linearGradient4554)" stroke-width="1.2274"/>
-  <rect x=".01215" y=".0060174" width="16.924" height="16.927" fill="none" opacity=".15" stroke-width="1.052"/>
- </g>
- <g transform="matrix(.49245 0 0 .49245 -13.676 8.6437)" fill-rule="evenodd">
-  <path transform="scale(.26458)" d="m171.31-39.182a5 5 0 0 0-0.65235 0.04297 5 5 0 0 0-3.3223 1.9102 5 5 0 0 0 0.92187 7.0137l9.5527 7.3398-37.383 0.08594a5 5 0 0 0-4.9902 5.0137 5 5 0 0 0 5.0137 4.9902l17.932-0.04102-33.768 26.004a6 6 0 0 0-1.0918 8.4082 6 6 0 0 0 8.416 1.0996l19.588-15.084a32.184 29.2 0 0 0 32.17 28.861 32.184 29.2 0 0 0 32.184-29.201 32.184 29.2 0 0 0-9.6309-20.826 5 5 0 0 0-0.0215-0.02149 5 5 0 0 0-0.52735-0.46875l-0.10351-0.08008-0.01-0.0078a32.184 29.2 0 0 0-2.1875-1.6797l-29.051-22.32a5 5 0 0 0-3.0391-1.0391z" fill="url(#linearGradient1902)" stroke-width="2.7224"/>
-  <ellipse cx="48.579" cy="1.2167" rx="5.2946" ry="4.8037" fill="url(#linearGradient1830)" stroke-width=".44786"/>
-  <ellipse cx="48.671" cy="1.0591" rx="3.287" ry="2.9793" fill="url(#linearGradient1694)" stroke-width=".2779"/>
- </g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   version="1.1"
+   viewBox="0 0 16.933 16.933"
+   id="svg43"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs25"><linearGradient
+       id="linearGradient923"><stop
+         style="stop-color:#d69a85;stop-opacity:1;"
+         offset="0"
+         id="stop919" /><stop
+         style="stop-color:#cb795d;stop-opacity:1;"
+         offset="1"
+         id="stop921" /></linearGradient><filter
+       id="filter1178"
+       x="-0.04799993"
+       y="-0.04799993"
+       width="1.0959999"
+       height="1.0959999"
+       color-interpolation-filters="sRGB"><feGaussianBlur
+         stdDeviation="0.30691955"
+         id="feGaussianBlur2" /></filter><linearGradient
+       id="linearGradient1694"
+       x1="48.597"
+       x2="48.597"
+       y1="-1.8124"
+       y2="3.8129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89214762,0,0,0.92700658,2.4703195,-1.0964435)"><stop
+         stop-color="#88c0d0"
+         offset="0"
+         id="stop5" /><stop
+         stop-color="#5e81ac"
+         offset="1"
+         id="stop7" /></linearGradient><linearGradient
+       id="linearGradient1830"
+       x1="48.461"
+       x2="48.461"
+       y1="-3.5809"
+       y2="6.0409"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89214762,0,0,0.92700658,2.4703195,-1.0964435)"><stop
+         stop-color="#eceff4"
+         offset="0"
+         id="stop10" /><stop
+         stop-color="#d8dee9"
+         offset="1"
+         id="stop12" /></linearGradient><linearGradient
+       id="linearGradient1902"
+       x1="176.3"
+       x2="176.3"
+       y1="-38.658"
+       y2="35.521"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26458,0,0,0.26458,-30.923261,-5.4432961)"><stop
+         stop-color="#d69a85"
+         offset="0"
+         id="stop15" /><stop
+         stop-color="#cb795d"
+         offset="1"
+         id="stop17" /></linearGradient><linearGradient
+       id="linearGradient4554"
+       x1="8.0262"
+       x2="8.0262"
+       y1="1.1559"
+       y2="16.004"
+       gradientUnits="userSpaceOnUse"><stop
+         stop-color="#4c566a"
+         offset="0"
+         id="stop20" /><stop
+         stop-color="#2e3440"
+         offset="1"
+         id="stop22" /></linearGradient><linearGradient
+       xlink:href="#linearGradient923"
+       id="linearGradient925"
+       x1="37.739799"
+       y1="-8.9749203"
+       x2="50.284859"
+       y2="14.631141"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.1535359,-0.81925484)" /><linearGradient
+       id="a"
+       x1="8.5869999"
+       x2="8.5869999"
+       y1="15.747"
+       y2="1.097"
+       gradientTransform="matrix(1.0178,0,0,1.0178,-0.15082699,-0.14267714)"
+       gradientUnits="userSpaceOnUse"><stop
+         stop-color="#2e3440"
+         offset="0"
+         id="stop313" /><stop
+         stop-color="#4c566a"
+         offset="1"
+         id="stop315" /></linearGradient><linearGradient
+       id="linearGradient1902-5"
+       x1="176.3"
+       x2="176.3"
+       y1="-38.658001"
+       y2="35.521"
+       gradientUnits="userSpaceOnUse"><stop
+         stop-color="#d69a85"
+         offset="0"
+         id="stop7439" /><stop
+         stop-color="#cb795d"
+         offset="1"
+         id="stop7441" /></linearGradient><linearGradient
+       id="linearGradient1830-6"
+       x1="48.460999"
+       x2="48.460999"
+       y1="-3.5809"
+       y2="6.0409002"
+       gradientUnits="userSpaceOnUse"><stop
+         stop-color="#eceff4"
+         offset="0"
+         id="stop7434" /><stop
+         stop-color="#d8dee9"
+         offset="1"
+         id="stop7436" /></linearGradient><linearGradient
+       id="linearGradient1694-2"
+       x1="48.597"
+       x2="48.597"
+       y1="-1.8124"
+       y2="3.8129001"
+       gradientUnits="userSpaceOnUse"><stop
+         stop-color="#88c0d0"
+         offset="0"
+         id="stop7429" /><stop
+         stop-color="#5e81ac"
+         offset="1"
+         id="stop7431" /></linearGradient><filter
+       style="color-interpolation-filters:sRGB"
+       id="filter7867"
+       x="-0.024410055"
+       y="-0.030204771"
+       width="1.0488201"
+       height="1.0604095"><feGaussianBlur
+         stdDeviation="0.25188229"
+         id="feGaussianBlur7869" /></filter></defs><image
+     x="0.92602342"
+     y="0.92602342"
+     width="16.108"
+     height="16.403999"
+     preserveAspectRatio="none"
+     xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPsAAAD7CAYAAACscuKmAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz AAA7DgAAOw4BzLahgwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAABENSURB VHic7Z3tdqO4EgDbTt7/ie8k+2MuE6XdX8JgA111jg8gsCSyFN0SePYmvbm9uwPwcr7f3YF3ceWL /crnBvtyyRvCVYTY6jyu8veAH7YS9/Q3gDNf3JW+n/n84D1UpD6l+GeTIerv2n1bfgeOwRoZo+9k 9Z1C/jNc0DMSW8d63z/DucM+eHJa5brsmZvCWznyBV+V9FZYn6kPrktV8u/C+kx9h+BoF/qs4Jno kfxRe3BdsuhtrWdlXr1R+cs5ysVekTySubr02jrK3wH2oyp5dZmVVdp/KUe4yDP5IoG9da8sWoce VKK4JXi2P6o7KnsZ77zYZySP1rNtXZfVNtJfHy/troidbVvrXrte2e686yKvTLJ5IkeSR/t13VF/ 4HpUZLekjoSP9us2Z2b1d+HVF3kUzWckHz93p1x/32rL61NlHxyT6qMxT/ZM6q9gXzXdr/Z3U155 MWcz6pngWupsm+gOC89GdS14tj0r/UuEf8UFPhPNI8GtdW9/JL21rPQZzkU2Kx5F9kh2a93b78nv 9W9X6T/3rFxq0TwT3Vp6+/R3dRtWH7y+wnWoRvZx24ve4/L+/+VtKLsZ39X1e327Ocdswp6yz4qu o7SWuyJ7NZXX/UP06+NNls2k8F/yW/ZR+FF6LfyX0ZebWi7sJvxeskeij9J5qbn+ZOVZGq/7YPXR K4Nzk0XTmUk5Lbq1vUg/Cu/VvZS/RPg9ZK+IriN6JHT02SKqW9twPaJJsTXRXcv+R+zrT6f2Osov be4u/NayWxJZsnvj8LuIfIgt9odxrJX+Z2N1q59eGVyDSnRfltbY/S627OP2TR5vBH+Gct2OJb3u 16bCbyn7GtEtoT3pPdm9qC7B0uszXJ/KZN2y/JZH0ccxuif7GOUt6ccbyHgjGK/HpR+bCb+V7BXR s1T9w1lGKbwlutW+1UevDK5NFOWjWfpFfC38XX7LPIo/Sq/TfD3Bt7RnTdxtIvwWsj8juiV4Jnsl dRdjafV15rzgPERi6P+uY0T1ZB/XF/H0LLyeoFuWi+RW2yKPUd4av4tTNsWzsmeiW4/TdKqeif4h j5Jnk3Fe32bOBc6LJXR07BhBx+OtCH9T68v1qFN4K6r/GdrRKfsY5a0bkO7rNM/IXhV9XHqR3BJd R/ZIcsbmEFG50VtS6aX+3NQxltxjmaj1hVH03YTfY8w+nvQipxXNLcm3EF2vR2UAIo+TYyMV4bXs Vhqvpddt/JEf0bXkbx2zW2JZkutxuiW6F9krouv2vT4CRETjeOtY7wUZ7/q0BNcsqfw4LND9eUr+ NbJXRbcm4fTnU+L03RNdt231Les7gIgtjR5Pe5mijvDj23PWdarH6h56ln7sx2rhZ2X3Tlp/ItE/ pRbRtexjW2Isq/0FGLGierTf+r6etdf7reie1ftlHPO22XhrnG49YstS9y0iutcvgFl0VPf2WSyP 0JZjs0iePfO3nsGPx0xF9xnZs/TdGqPPjNWtF2Ys2XVfrG2ALfDEHyflLEbprbo8rFd1R9csycvC PxvZI8mjMXom+ii8GEvdD4C9saLqsq2FHKXNGOX+MMpFHlP6XR+9WSm794mE12XRa7CW7F6fAF6F jqTRdXgv1Je9ohsNB6ai+0d2wFCZXuoxupb501nOpO9jm2NfEB3eiXUNRtdrhvduvt6v16c8qMge RXUrdR+l/hRf9rWiAxyFtcJXJu088at9eSCTPZqUy8bokejWizOR6ERzOCre5PFsoLKidyXSRxPX v5iVPRubj3J7abz345ZIdICjUxHeO86Sem2Ed6nKPi6tN+S8GXcrskfp+9iWXgc4Opnw1fTde0nH i/AlTyLZK1Hde25eGatHj9jKJwBwMJ5J6S2ZPcG9SO96U5Hdi+qjuJH00ThdvwqbdhjgBFRTeo33 +E2Mdf2d1RN0s2P12VdidZ2IDlcju6b1eF2GbU92ccqitv+RvVQTSR/NymdvxXmiA1wZK51fXq0d l/ozvidvuVN6uSaL7NWxuvWMXaf51qSc/gMgPlyJKJ2Pxuc6Ta/M1qdYr/N5wnlR3Yru2Yy71Rai wxXxrvEsQ9ZlUXactSsi8bu7XnSPOmndBEjdAX5TdcrzK3LKdUvLnj0iiO5E1R+1WHUjP1yZ6Fqf daqaKT9sV36VoztkRexM8iiyIzp0IErhs4zZ8m06U/Zk91L4sSySe1VnAJpS8Sea4C6l8pUxu+5Q FtVnxuvcBKATlegeTXp7NwSvjV/cCwdFd5HZlB0AbKqpfZRte/WKSP7oLZJcz75bEwdRZ7gJQEe8 jFnE9q3impW+P/gVjdmjDnh3m0h4swMAjckCa+RWFFhNstn4TPS1KTzSQ2fWDJlnPDPrrzx603ef aAxhNcS4HSBGO+JJHz3lSj27DwdaHdAVVe461vFeGwDdeYVnN5HaG3RZA9XUPeoMQDcqnqzxz20j e6nG64DXiN4HAHNEPln+eXU8UPnVW3ViIBqzA0CM5000ZzY1SZe9QZfdOaJUw2wQAFwqgdY6Th9v Uv0hjG5YjKUE5UgP4BNN0uljosm5kOqjt0rDALAPlQCbOnivHKQqfKZBbgoAP1Rn5K3vzEb2W+Un rtl+Zt4B9mVmzO7un/nHKyplY8cAYB3Tj9UqVP8Nuk0aA4DNsCb1dPkvKr9ntyq0GuUmALA9kV9T 82Qzj94qHSALAFhP1adVXs38u/ERSA2wH5v4tTayVzrADQBgnq28mnpdFgAuBLIDNGGN7KTnAO9n 2kMiO0ATkB2gCcgO0ARkB2gCsgM0AdkBmoDsAE1AdoAmIDtAE5AdoAnIDtAEZAdoArIDNAHZAZqA 7ABNQHaAJiA7QBOQHaAJyA7QBGQHaAKyAzQB2QGagOwATUB2gCYgO0ATkB2gCcgO0ARkB2gCsgM0 AdkBmoDsAE1AdoAmIDtAE5AdoAnIDtAEZAdoArIDNAHZAZqA7ABNQHaAJiA7QBOQHaAJyA7QBGQH aAKyAzQB2QGagOwATUB2gCYgO0ATkB2gCcgO0ARkB2gCsgM0AdkBmoDsAE1AdoAmIDtAE5AdoAnI DtAEZAdoArIDNAHZAZqA7ABNQHaAJiA7QBOQHaAJyA7QBGQHaAKyAzQB2QGagOwATUB2gCYgO0AT kB2gCcgO0ARkB2gCsgM0AdkBmoDsAE1AdoAmIDtAE5AdoAnIDtAEZAdoArIDNAHZAZqA7ABNQHaA JiA7QBOQHaAJyA7QBGQHaAKyAzQB2QGagOwATUB2gCYgO0ATkB2gCcgO0ARkB2gCsgM0AdkBmoDs AE1AdoAmIDtAE5AdoAnIDtAEZAdowhrZvzfvBQDMMu0hkR2gCcgO0ARL9mp6kB1Hug8wz1ZePRy3 VWRHbID92MSvtbJ/q6Uu97YBwKfq04xX/469W4XBl6xj1nQAAGpEfnlOmkSRfWzk2ygHgPehnUyD 7jNjdq/SqbsNADwQObTaLU/27C6hoz5yA+yH9qzi5QP34IuzDSI9wLZYTq0NtN+VND5rUIz9UV0A 8JdZb54KtDNjdi+yVx4PIDmAjzXZVgmwm87Gz4zZKzcCAPDxInZlCC2SyF95XdZq0LqrVF+0AYBH qhny7A3gH9lsvFXuRXXdQSQHmCfyyfLPq+MBLXsW1XWZdUwmOTcBgJona/xz27hbhUaZ18BXsUNe GwDdqXhm+WYdr+v7VZbNxlsVZeN3Lzt4aBwARMT3bFyvzJmFXlXH7FmDlc4AwF/WzInNeFYas1tf yBr/ctatSI/8AD9YblTd8jxzHcsevUVjB92RSHRSeYC/RMNcT/jMtVJgrfyePUotorsNqTxAnYpH 2YS4V6+I1NJ43Rnd4JfxqaQdVhsAV0Zf+5HQnleWh14bv6j8xNW7i3idiO5AAPBIxR/LN+u7Io5v 1R/CZJ2J7kBEd4BaVK86tSqYVt6g09tR+p6lHl7dCA9XJrrW93LqYXvm36CbuftUojtAV6pRPRsu l1N4kbn/ScSM9Flab7XFDQCuSHS9Z4GzOumdtSsiIh/OgTe1tMpuw+eutnW5Pr7SDsDZsUS3JtdG mf84n69h6U3ShXwWOnsb1seK9R3pJnZUvw37bkankBu64GXFWXacDY3H+l28yC4yH92tjz6mUrde BzgjWfpupetjBPei+ij+WJ/X9j8qsi/r1vaM6JUbAcLDFYjS92isruUet7PZ+DSNj2QXWRfddZm1 Lc621xbAWaiIbqXqnuRa9mys7kpflX1Z97az6O0db7XhlQEcnUx0/XjaEt2K8DNPtVxmZdf7PKnF 2WeVW/VmbQMcjWrqHqXtM6KXZuBHMtlF/LG6t62XUbpvtWHV4x0H8G68NHrmXZS1EV23v3o2fqQi XyR89t1oG+HhqKwV3XuW7ok+K73JrOzLeiRydb8lbVV4rwzgFVhirYno3nh97bvwIVXZReajejbx Zm2vKUd6eCVRNF+W0csyUVS3Zt6ffplmYa3sa1PyNd9dUwfA1mRj5Wwyrpq+e4/aVk3KjczILuIL V5mgs74XlWfHzWYFALN4YnnR3Ivq3ptx/xM/qlcftZXln5VdJH72rvdX6qge651UVBfiwyyRPJbk yzJL3bXsWnQtvE7hRWLpU7aQfeb42fpnyb6L/KDJhPGeny/LakQfZbdE934A83T6vrBGdpFc+C3H 1NWTZBwPW1GdhItEj9L36s9Xteiro7rIetlFasJXs4DsJGZPjFl7mCG75iLJK6JHwlvR3Hrc9pTo ItvJHm17wmfPKr19HtF+RIeMNdF8jejem3JPP1rLeEZ2EVvwNe+0R3dRq7xah7dtwQ3huswGihnR Ky/JeI/WrN+oL8ux3ZlzcXlWdpHnx+xemlKRPnscMXN33HQyBN7KzH9L67qzIncmePVHLdEjtt1E F8n/WaoK32Kn57dh/Uv+/nt0X873v+XvjWdZvw/bd+OztHlT694PcHR/RO3zzguuR2X4GEV07/Ha 7CuwM4/YvH5PsYXsInXhx2fm1mcUXIv+IT83jeVzG8puYktvLcXZhutTSdmXZSb6uG6l55HoVuZg 9c8rm2Yr2UVqwov8ln45zhJey77Ur2W/D3VG/5rt7ONCuA6ZQJbgy7YlZia7V2aNzXeP6Atbyi7i C2+xnOx9ONaSfPnoqD7KrqWP0noRInxHIoks4byIrlP4b4nTdOsGYX2yPj7N1rKL2MLr6D5G6VF6 7w9hiW7JrkWfSem9Mjg3z47RM9mzMbwVxV8uusg+sovUhBf5HYllOMaSXG9bonvCi8TRHcmvj5W2 L+uVqO6l71akj8blluC7iy6yn+wideEXRvG/1fHjJFw1qi/DgyzCi7MN18GTyRurW3J6Y+7KePzt oou85gKP0mVrMk0LG617+59J5aNyOA+eNLMpvBXdvbJMdKvdSp834ZUXtRdJ14gfRXMvfSey96Ua 2cd1T/bKtlWf1a7Xv1149QU+E+XH9ehTGadHokd/A24A5yMSxxq3e6l8JcpnEfzt0XzkXRdzFFVn pI/2efVk7cM1sUQf1yuiZ/uteqw2re3deedFHkX5cT0St7Kt66q0DdciiqjVlD7attYrbb+UI1zg M9LrZSZ2JW0/wt8AXkMUXbP0u5KeH1LyhaNc6JVZ8eoNIFp6bR3l7wD7kcmXCVwV2xP6raKLHO8i r0g/bldvBl7dRzt/2J9Z6Sv7vXqj8pdz5It9VvxofaY+uC5VIatR+/CCj5zhQp95NDYTvc9w7rAP M5LOzKIfUvKFs13wa5+JrznPs/1t4Ic10j0j8aElXzjzBV3p+5nPD95DRdxTyK25igxbncdV/h7w w1ZinlLwkStf3Fc+N9iX04tt0V2I7uffkUuKXOE/2+1WpyDcm1gAAAAASUVORK5CYII="
+     id="image328" /><rect
+     x="0.92602342"
+     y="0.92602342"
+     width="15.081"
+     height="15.081"
+     rx="3.0536001"
+     ry="3.0534999"
+     fill="url(#a)"
+     stroke-width="1.0178"
+     id="rect330"
+     style="fill:url(#a)" /><g
+     transform="matrix(0.49245,0,0,0.49245,-13.568504,8.9041266)"
+     fill-rule="evenodd"
+     id="g41"><g
+       transform="translate(0.01057189,-0.52883381)"
+       fill-rule="evenodd"
+       id="g7465"><path
+         d="m 45.3252,-10.366777 a 1.3229,1.3229 0 0 0 -0.172599,0.01137 1.3229,1.3229 0 0 0 -0.879014,0.5054011 1.3229,1.3229 0 0 0 0.243908,1.855685 l 2.527454,1.941964 -9.890795,0.02274 a 1.3229,1.3229 0 0 0 -1.320307,1.326525 1.3229,1.3229 0 0 0 1.326525,1.320307 l 4.744449,-0.01085 -8.934338,6.880138 a 1.58748,1.58748 0 0 0 -0.288868,2.224642 1.58748,1.58748 0 0 0 2.226705,0.290932 l 5.182593,-3.990925 a 8.5152427,7.725736 0 0 0 8.511539,7.636044 8.5152427,7.725736 0 0 0 8.515242,-7.726001 8.5152427,7.725736 0 0 0 -2.548143,-5.510143 1.3229,1.3229 0 0 0 -0.0057,-0.0057 1.3229,1.3229 0 0 0 -0.139526,-0.124022 l -0.02739,-0.02119 -0.0026,-0.0021 a 8.5152427,7.725736 0 0 0 -0.5788,-0.444368 l -7.686314,-5.9054261 a 1.3229,1.3229 0 0 0 -0.804085,-0.274925 z"
+         fill="url(#linearGradient1902)"
+         stroke-width="0.720293"
+         id="path7459-2"
+         style="fill:#2e3440;fill-opacity:1;filter:url(#filter7867);opacity:0.5" /><path
+         d="m 171.31,-39.182 a 5,5 0 0 0 -0.65235,0.04297 5,5 0 0 0 -3.3223,1.9102 5,5 0 0 0 0.92187,7.0137 l 9.5527,7.3398 -37.383,0.08594 a 5,5 0 0 0 -4.9902,5.0137 5,5 0 0 0 5.0137,4.9902 l 17.932,-0.04102 -33.768,26.004 a 6,6 0 0 0 -1.0918,8.4082 6,6 0 0 0 8.416,1.0996 l 19.588,-15.084 a 32.184,29.2 0 0 0 32.17,28.861 32.184,29.2 0 0 0 32.184,-29.201 32.184,29.2 0 0 0 -9.6309,-20.826 5,5 0 0 0 -0.0215,-0.02149 5,5 0 0 0 -0.52735,-0.46875 l -0.10351,-0.08008 -0.01,-0.0078 a 32.184,29.2 0 0 0 -2.1875,-1.6797 l -29.051,-22.32 a 5,5 0 0 0 -3.0391,-1.0391 z"
+         fill="url(#linearGradient1902)"
+         stroke-width="2.7224"
+         id="path7459"
+         style="fill:url(#linearGradient1902-5)"
+         transform="scale(0.26458)" /><ellipse
+         cx="48.578999"
+         cy="1.2167"
+         rx="5.2946"
+         ry="4.8037"
+         fill="url(#linearGradient1830)"
+         stroke-width="0.44786"
+         id="ellipse7461"
+         style="display:inline;fill:url(#linearGradient1830-6)" /><ellipse
+         cx="48.671001"
+         cy="1.0591"
+         rx="3.2869999"
+         ry="2.9793"
+         fill="url(#linearGradient1694)"
+         stroke-width="0.2779"
+         id="ellipse7463"
+         style="display:inline;fill:url(#linearGradient1694-2)" /></g></g></svg>


### PR DESCRIPTION
The Blender icon was missing drop shadows. Most icons (at least the ones I use) have drop shadows. I don't know the design guidelines, but I'm assuming you want drop shadows based on my other pull requests, with drop shadows, not having been altered by you.