### PR TITLE
Fix symlink for spitfire-audio

### DIFF
--- a/links/apps/scalable/spitfire-audio.svg
+++ b/links/apps/scalable/spitfire-audio.svg
@@ -1,1 +1,1 @@
-../../../src/apps/scalable/spitfire.svg
+spitfire.svg


### PR DESCRIPTION
While packaging this repository, a linter was complaining that a symlink was broken in the package, and it turns out that indeed if I go to /usr/share/icons, the spitfire-audio.svg file points to a broken link, because it points to ../../../src as well.

So in this PR I propose to use a relative symlink to fix the icon when installed.